### PR TITLE
Rework entire HTTP request pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -191,6 +191,6 @@ ModelManifest.xml
 
 # Consul data files
 consul-data/
-consul.exe
+consul*.exe
 NuGet.exe
 *.nupkg

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,23 @@
 # Changelog
 
+## BREAKING CHANGES FOR 0.6.0.x
+* The `Client` class has been renamed `ConsulClient`. The interface
+  remains the same - `IConsulClient`.
+* The `ConsulClientConfiguration` class no longer accepts a string
+  `Address` property to the Consul server. It is now a `System.Uri`
+  named `Address`.
+
+## 2015-11-21
+* Reworked the entire Client class to use `System.Net.HttpClient` as its
+  underpinning rather than `WebRequest`/`WebResponse`.
+* Moved all tests to Xunit.
+* Converted all uses of `System.Web.HttpUtility.UrlPathEncode` to
+  `System.Uri.EscapeDataString`.
+
 ## 2015-11-09
 
 * Added coordinates API. *WARNING*: No check is done to see if the API
-  is available. If used against a 0.5.2 agent, a `WebException` will be
+  is available. If used against a 0.5.2 agent, an exception will be
   thrown because the agent does not understand the coordinate URL.
 * Fixed bug in tests for session renewal.
 

--- a/Consul.Test/ACLTest.cs
+++ b/Consul.Test/ACLTest.cs
@@ -29,7 +29,7 @@ namespace Consul.Test
         {
             Skip.If(string.IsNullOrEmpty(ConsulRoot));
 
-            var client = new Client(new ConsulClientConfiguration() { Token = ConsulRoot });
+            var client = new ConsulClient(new ConsulClientConfiguration() { Token = ConsulRoot });
             var aclEntry = new ACLEntry()
             {
                 Name = "API Test",
@@ -57,7 +57,7 @@ namespace Consul.Test
         {
             Skip.If(string.IsNullOrEmpty(ConsulRoot));
 
-            var client = new Client(new ConsulClientConfiguration() { Token = ConsulRoot });
+            var client = new ConsulClient(new ConsulClientConfiguration() { Token = ConsulRoot });
 
             var cloneRequest = client.ACL.Clone(ConsulRoot);
             var aclID = cloneRequest.Response;
@@ -82,7 +82,7 @@ namespace Consul.Test
         {
             Skip.If(string.IsNullOrEmpty(ConsulRoot));
 
-            var client = new Client(new ConsulClientConfiguration() { Token = ConsulRoot });
+            var client = new ConsulClient(new ConsulClientConfiguration() { Token = ConsulRoot });
 
             var aclEntry = client.ACL.Info(ConsulRoot);
 
@@ -97,7 +97,7 @@ namespace Consul.Test
         {
             Skip.If(string.IsNullOrEmpty(ConsulRoot));
 
-            var client = new Client(new ConsulClientConfiguration() { Token = ConsulRoot });
+            var client = new ConsulClient(new ConsulClientConfiguration() { Token = ConsulRoot });
 
             var aclList = client.ACL.List();
 

--- a/Consul.Test/AgentTest.cs
+++ b/Consul.Test/AgentTest.cs
@@ -26,7 +26,7 @@ namespace Consul.Test
         [Fact]
         public void Agent_Self()
         {
-            var client = new Client();
+            var client = new ConsulClient();
 
             var info = client.Agent.Self();
 
@@ -38,7 +38,7 @@ namespace Consul.Test
         [Fact]
         public void Agent_Members()
         {
-            var client = new Client();
+            var client = new ConsulClient();
 
             var members = client.Agent.Members(false);
 
@@ -49,7 +49,7 @@ namespace Consul.Test
         [Fact]
         public void Agent_Services()
         {
-            var client = new Client();
+            var client = new ConsulClient();
             var registration = new AgentServiceRegistration()
             {
                 Name = "foo",
@@ -77,7 +77,7 @@ namespace Consul.Test
         [Fact]
         public void Agent_Services_CheckPassing()
         {
-            var client = new Client();
+            var client = new ConsulClient();
             var registration = new AgentServiceRegistration()
             {
                 Name = "foo",
@@ -105,7 +105,7 @@ namespace Consul.Test
         [Fact]
         public void Agent_Services_CheckTTLNote()
         {
-            var client = new Client();
+            var client = new ConsulClient();
             var registration = new AgentServiceRegistration()
             {
                 Name = "foo",
@@ -146,7 +146,7 @@ namespace Consul.Test
         [Fact]
         public void Agent_ServiceAddress()
         {
-            var client = new Client();
+            var client = new ConsulClient();
             var registration1 = new AgentServiceRegistration()
             {
                 Name = "foo1",
@@ -175,7 +175,7 @@ namespace Consul.Test
         [Fact]
         public void Agent_Services_MultipleChecks()
         {
-            var client = new Client();
+            var client = new ConsulClient();
             var registration = new AgentServiceRegistration()
             {
                 Name = "foo",
@@ -208,7 +208,7 @@ namespace Consul.Test
         [Fact]
         public void Agent_SetTTLStatus()
         {
-            var client = new Client();
+            var client = new ConsulClient();
             var registration = new AgentServiceRegistration()
             {
                 Name = "foo",
@@ -232,7 +232,7 @@ namespace Consul.Test
         [Fact]
         public void Agent_Checks()
         {
-            var client = new Client();
+            var client = new ConsulClient();
             var registration = new AgentCheckRegistration
             {
                 Name = "foo",
@@ -250,7 +250,7 @@ namespace Consul.Test
         [Fact]
         public void Agent_CheckStartPassing()
         {
-            var client = new Client();
+            var client = new ConsulClient();
             var registration = new AgentCheckRegistration
             {
                 Name = "foo",
@@ -269,7 +269,7 @@ namespace Consul.Test
         [Fact]
         public void Agent_Checks_ServiceBound()
         {
-            var client = new Client();
+            var client = new ConsulClient();
 
             var serviceReg = new AgentServiceRegistration()
             {
@@ -296,7 +296,7 @@ namespace Consul.Test
         [Fact]
         public void Agent_Join()
         {
-            var client = new Client();
+            var client = new ConsulClient();
             var info = client.Agent.Self();
             client.Agent.Join(info.Response["Config"]["AdvertiseAddr"], false);
             // Success is not throwing an exception
@@ -305,7 +305,7 @@ namespace Consul.Test
         [Fact]
         public void Agent_ForceLeave()
         {
-            var client = new Client();
+            var client = new ConsulClient();
             client.Agent.ForceLeave("foo");
             // Success is not throwing an exception
         }
@@ -313,7 +313,7 @@ namespace Consul.Test
         [Fact]
         public void Agent_ServiceMaintenance()
         {
-            var client = new Client();
+            var client = new ConsulClient();
 
             var serviceReg = new AgentServiceRegistration()
             {
@@ -350,7 +350,7 @@ namespace Consul.Test
         [Fact]
         public void Agent_NodeMaintenance()
         {
-            var client = new Client();
+            var client = new ConsulClient();
 
             client.Agent.EnableNodeMaintenance("broken");
             var checks = client.Agent.Checks();

--- a/Consul.Test/AssemblyTest.cs
+++ b/Consul.Test/AssemblyTest.cs
@@ -12,7 +12,7 @@ namespace Consul.Test
         [Fact]
         public void Assembly_IsStrongNamed()
         {
-            Type type = typeof(Consul.Client);
+            Type type = typeof(Consul.ConsulClient);
             string name = type.Assembly.FullName.ToString();
             Trace.WriteLine(name);
             Assert.True(type.Assembly.FullName.Contains("PublicKeyToken"));

--- a/Consul.Test/CatalogTest.cs
+++ b/Consul.Test/CatalogTest.cs
@@ -25,7 +25,7 @@ namespace Consul.Test
         [Fact]
         public void Catalog_Datacenters()
         {
-            var client = new Client();
+            var client = new ConsulClient();
             var datacenterList = client.Catalog.Datacenters();
 
             Assert.NotEqual(0, datacenterList.Response.Length);
@@ -34,7 +34,7 @@ namespace Consul.Test
         [Fact]
         public void Catalog_Nodes()
         {
-            var client = new Client();
+            var client = new ConsulClient();
             var nodeList = client.Catalog.Nodes();
 
 
@@ -48,7 +48,7 @@ namespace Consul.Test
         [Fact]
         public void Catalog_Services()
         {
-            var client = new Client();
+            var client = new ConsulClient();
             var servicesList = client.Catalog.Services();
 
 
@@ -59,7 +59,7 @@ namespace Consul.Test
         [Fact]
         public void Catalog_Service()
         {
-            var client = new Client();
+            var client = new ConsulClient();
             var serviceList = client.Catalog.Service("consul");
 
             Assert.NotEqual((ulong)0, serviceList.LastIndex);
@@ -69,7 +69,7 @@ namespace Consul.Test
         [Fact]
         public void Catalog_Node()
         {
-            var client = new Client();
+            var client = new ConsulClient();
 
             var node = client.Catalog.Node(client.Agent.NodeName);
 
@@ -80,7 +80,7 @@ namespace Consul.Test
         [Fact]
         public void Catalog_RegistrationDeregistration()
         {
-            var client = new Client();
+            var client = new ConsulClient();
             var service = new AgentService()
             {
                 ID = "redis1",

--- a/Consul.Test/Consul.Test.csproj
+++ b/Consul.Test/Consul.Test.csproj
@@ -52,6 +52,7 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Net.Http" />
+    <Reference Include="System.Net.Http.WebRequest" />
     <Reference Include="Validation, Version=2.0.0.0, Culture=neutral, PublicKeyToken=2fc06f0d701809a7, processorArchitecture=MSIL">
       <HintPath>..\packages\Validation.2.0.6.15003\lib\portable-net40+sl50+win+wpa81+wp80+Xamarin.iOS10+MonoAndroid10+MonoTouch10\Validation.dll</HintPath>
       <Private>True</Private>

--- a/Consul.Test/CoordinateTest.cs
+++ b/Consul.Test/CoordinateTest.cs
@@ -8,7 +8,7 @@ namespace Consul.Test
         [SkippableFact]
         public void Coordinate_Datacenters()
         {
-            var client = new Client();
+            var client = new ConsulClient();
 
             var info = client.Agent.Self();
 
@@ -23,7 +23,7 @@ namespace Consul.Test
         [SkippableFact]
         public void Coordinate_Nodes()
         {
-            var client = new Client();
+            var client = new ConsulClient();
 
             var info = client.Agent.Self();
 

--- a/Consul.Test/EventTest.cs
+++ b/Consul.Test/EventTest.cs
@@ -27,7 +27,7 @@ namespace Consul.Test
         [Fact]
         public void Event_FireList()
         {
-            var client = new Client();
+            var client = new ConsulClient();
 
             var userevent = new UserEvent()
             {

--- a/Consul.Test/HealthTest.cs
+++ b/Consul.Test/HealthTest.cs
@@ -26,7 +26,7 @@ namespace Consul.Test
         [Fact]
         public void Health_Node()
         {
-            var client = new Client();
+            var client = new ConsulClient();
 
             var info = client.Agent.Self();
             var checks = client.Health.Node((string)info.Response["Config"]["NodeName"]);
@@ -38,7 +38,7 @@ namespace Consul.Test
         [Fact]
         public void Health_Checks()
         {
-            var client = new Client();
+            var client = new ConsulClient();
 
             var registration = new AgentServiceRegistration()
             {
@@ -66,7 +66,7 @@ namespace Consul.Test
         [Fact]
         public void Health_Service()
         {
-            var client = new Client();
+            var client = new ConsulClient();
 
             var checks = client.Health.Service("consul", "", true);
             Assert.NotEqual((ulong)0, checks.LastIndex);
@@ -76,7 +76,7 @@ namespace Consul.Test
         [Fact]
         public void Health_State()
         {
-            var client = new Client();
+            var client = new ConsulClient();
 
             var checks = client.Health.State(CheckStatus.Any);
             Assert.NotEqual((ulong)0, checks.LastIndex);

--- a/Consul.Test/KVTest.cs
+++ b/Consul.Test/KVTest.cs
@@ -32,13 +32,12 @@ namespace Consul.Test
 
         internal static string GenerateTestKeyName()
         {
-            StackFrame frame = new StackFrame(1);
             var keyChars = new char[16];
             for (var i = 0; i < keyChars.Length; i++)
             {
                 keyChars[i] = Convert.ToChar(Random.Next(65, 91));
             }
-            return (new string(keyChars)) + "_" + frame.GetMethod().Name;
+            return new string(keyChars);
         }
 
         [Fact]

--- a/Consul.Test/LockTest.cs
+++ b/Consul.Test/LockTest.cs
@@ -24,12 +24,13 @@ using Xunit;
 
 namespace Consul.Test
 {
+    [Trait("speed","slow")]
     public class LockTest
     {
         [Fact]
         public void Lock_AcquireRelease()
         {
-            var client = new Client();
+            var client = new ConsulClient();
             const string keyName = "test/lock/acquirerelease";
             var lockKey = client.CreateLock(keyName);
 
@@ -72,7 +73,7 @@ namespace Consul.Test
         [Fact]
         public void Lock_EphemeralAcquireRelease()
         {
-            var client = new Client();
+            var client = new ConsulClient();
             const string keyName = "test/lock/ephemerallock";
             var sessionId = client.Session.Create(new SessionEntry { Behavior = SessionBehavior.Delete });
             using (var l = client.AcquireLock(new LockOptions(keyName) { Session = sessionId.Response }, CancellationToken.None))
@@ -86,7 +87,7 @@ namespace Consul.Test
         [Fact]
         public void Lock_Disposable()
         {
-            var client = new Client();
+            var client = new ConsulClient();
 
             const string keyName = "test/lock/disposable";
             using (var l = client.AcquireLock(keyName))
@@ -97,7 +98,7 @@ namespace Consul.Test
         [Fact]
         public void Lock_ExecuteAction()
         {
-            var client = new Client();
+            var client = new ConsulClient();
 
             const string keyName = "test/lock/action";
             client.ExecuteLocked(keyName, () => Assert.True(true));
@@ -105,7 +106,7 @@ namespace Consul.Test
         [Fact]
         public void Lock_AcquireWaitRelease()
         {
-            var client = new Client();
+            var client = new ConsulClient();
 
             const string keyName = "test/lock/acquirewaitrelease";
 
@@ -134,7 +135,7 @@ namespace Consul.Test
         [Fact]
         public void Lock_ContendWait()
         {
-            var client = new Client();
+            var client = new ConsulClient();
 
             const string keyName = "test/lock/contend";
             const int contenderPool = 3;
@@ -172,7 +173,7 @@ namespace Consul.Test
         [Fact]
         public void Lock_ContendFast()
         {
-            var client = new Client();
+            var client = new ConsulClient();
 
             const string keyName = "test/lock/contend";
             const int contenderPool = 10;
@@ -210,7 +211,7 @@ namespace Consul.Test
         [Fact]
         public void Lock_Contend_LockDelay()
         {
-            var client = new Client();
+            var client = new ConsulClient();
 
             const string keyName = "test/lock/contendlockdelay";
 
@@ -248,7 +249,7 @@ namespace Consul.Test
         [Fact]
         public void Lock_Destroy()
         {
-            var client = new Client();
+            var client = new ConsulClient();
 
             const string keyName = "test/lock/contendlockdelay";
 
@@ -313,7 +314,7 @@ namespace Consul.Test
         [Fact]
         public void Lock_RunAction()
         {
-            var client = new Client();
+            var client = new ConsulClient();
 
             const string keyName = "test/lock/runaction";
 
@@ -337,7 +338,7 @@ namespace Consul.Test
         [Fact]
         public void Lock_AbortAction()
         {
-            var client = new Client();
+            var client = new ConsulClient();
 
             const string keyName = "test/lock/abort";
 
@@ -373,7 +374,7 @@ namespace Consul.Test
         [Fact]
         public void Lock_ReclaimLock()
         {
-            var client = new Client();
+            var client = new ConsulClient();
 
             const string keyName = "test/lock/reclaim";
 
@@ -442,7 +443,7 @@ namespace Consul.Test
         [Fact]
         public void Lock_SemaphoreConflict()
         {
-            var client = new Client();
+            var client = new ConsulClient();
 
             const string keyName = "test/lock/semaphoreconflict";
 
@@ -479,7 +480,7 @@ namespace Consul.Test
         [Fact]
         public void Lock_ForceInvalidate()
         {
-            var client = new Client();
+            var client = new ConsulClient();
 
             const string keyName = "test/lock/forceinvalidate";
 
@@ -520,7 +521,7 @@ namespace Consul.Test
         [Fact]
         public void Lock_DeleteKey()
         {
-            var client = new Client();
+            var client = new ConsulClient();
 
             const string keyName = "test/lock/deletekey";
 

--- a/Consul.Test/SemaphoreTest.cs
+++ b/Consul.Test/SemaphoreTest.cs
@@ -24,12 +24,13 @@ using Xunit;
 
 namespace Consul.Test
 {
+    [Trait("speed", "slow")]
     public class SemaphoreTest
     {
         [Fact]
         public void Semaphore_BadLimit()
         {
-            var client = new Client();
+            var client = new ConsulClient();
 
             const string keyName = "test/semaphore/badlimit";
 
@@ -72,7 +73,7 @@ namespace Consul.Test
         [Fact]
         public void Semaphore_AcquireRelease()
         {
-            var client = new Client();
+            var client = new ConsulClient();
 
             const string keyName = "test/semaphore/acquirerelease";
 
@@ -118,7 +119,7 @@ namespace Consul.Test
         [Fact]
         public void Semaphore_Disposable()
         {
-            var client = new Client();
+            var client = new ConsulClient();
 
             const string keyName = "test/semaphore/disposable";
             using (var semaphore = client.AcquireSemaphore(keyName, 2))
@@ -129,7 +130,7 @@ namespace Consul.Test
         [Fact]
         public void Semaphore_ExecuteAction()
         {
-            var client = new Client();
+            var client = new ConsulClient();
 
             const string keyName = "test/semaphore/action";
             client.ExecuteInSemaphore(keyName, 2, () => Assert.True(true));
@@ -138,7 +139,7 @@ namespace Consul.Test
         public void Semaphore_AcquireWaitRelease()
         {
 
-            var client = new Client();
+            var client = new ConsulClient();
 
             const string keyName = "test/semaphore/acquirewaitrelease";
 
@@ -168,7 +169,7 @@ namespace Consul.Test
         [Fact]
         public void Semaphore_ContendWait()
         {
-            var client = new Client();
+            var client = new ConsulClient();
 
             const string keyName = "test/semaphore/contend";
             const int contenderPool = 4;
@@ -203,7 +204,7 @@ namespace Consul.Test
         [Fact]
         public void Semaphore_ContendFast()
         {
-            var client = new Client();
+            var client = new ConsulClient();
 
             const string keyName = "test/semaphore/contend";
             const int contenderPool = 15;
@@ -238,7 +239,7 @@ namespace Consul.Test
         [Fact]
         public void Semaphore_Destroy()
         {
-            var c = new Client();
+            var c = new ConsulClient();
 
             const string keyName = "test/semaphore/destroy";
 
@@ -303,7 +304,7 @@ namespace Consul.Test
         [Fact]
         public void Semaphore_ForceInvalidate()
         {
-            var client = new Client();
+            var client = new ConsulClient();
 
             const string keyName = "test/semaphore/forceinvalidate";
 
@@ -346,7 +347,7 @@ namespace Consul.Test
         [Fact]
         public void Semaphore_DeleteKey()
         {
-            var client = new Client();
+            var client = new ConsulClient();
 
             const string keyName = "test/semaphore/deletekey";
 
@@ -389,7 +390,7 @@ namespace Consul.Test
         [Fact]
         public void Semaphore_Conflict()
         {
-            var client = new Client();
+            var client = new ConsulClient();
 
             const string keyName = "test/semaphore/conflict";
 

--- a/Consul.Test/SessionTest.cs
+++ b/Consul.Test/SessionTest.cs
@@ -27,7 +27,7 @@ namespace Consul.Test
         [Fact]
         public void Session_CreateDestroy()
         {
-            var client = new Client();
+            var client = new ConsulClient();
             var sessionRequest = client.Session.Create();
             var id = sessionRequest.Response;
             Assert.True(sessionRequest.RequestTime.TotalMilliseconds > 0);
@@ -40,7 +40,7 @@ namespace Consul.Test
         [Fact]
         public void Session_CreateNoChecksDestroy()
         {
-            var client = new Client();
+            var client = new ConsulClient();
             var sessionRequest = client.Session.CreateNoChecks();
 
             var id = sessionRequest.Response;
@@ -54,7 +54,7 @@ namespace Consul.Test
         [Fact]
         public void Session_CreateRenewDestroy()
         {
-            var client = new Client();
+            var client = new ConsulClient();
             var sessionRequest = client.Session.Create(new SessionEntry() { TTL = TimeSpan.FromSeconds(10) });
 
             var id = sessionRequest.Response;
@@ -75,7 +75,7 @@ namespace Consul.Test
         [Fact]
         public void Session_CreateRenewDestroyRenew()
         {
-            var client = new Client();
+            var client = new ConsulClient();
             var sessionRequest = client.Session.Create(new SessionEntry() { TTL = TimeSpan.FromSeconds(10) });
 
             var id = sessionRequest.Response;
@@ -105,7 +105,7 @@ namespace Consul.Test
         [Fact]
         public void Session_Create_RenewPeriodic_Destroy()
         {
-            var client = new Client();
+            var client = new ConsulClient();
             var sessionRequest = client.Session.Create(new SessionEntry() { TTL = TimeSpan.FromSeconds(10) });
 
             var id = sessionRequest.Response;
@@ -115,7 +115,7 @@ namespace Consul.Test
             var tokenSource = new CancellationTokenSource();
             var ct = tokenSource.Token;
 
-            var renewTask = client.Session.RenewPeriodic(TimeSpan.FromSeconds(1), id, WriteOptions.Empty, ct);
+            var renewTask = client.Session.RenewPeriodic(TimeSpan.FromSeconds(1), id, WriteOptions.Default, ct);
 
             var infoRequest = client.Session.Info(id);
             Assert.True(infoRequest.LastIndex > 0);
@@ -127,7 +127,7 @@ namespace Consul.Test
 
             try
             {
-                renewTask.Wait(1000);
+                renewTask.Wait(3000);
                 Assert.True(false, "timedout: missing session did not terminate renewal loop");
             }
             catch (AggregateException ae)
@@ -139,7 +139,7 @@ namespace Consul.Test
         [Fact]
         public void Session_Create_RenewPeriodic_TTLExpire()
         {
-            var client = new Client();
+            var client = new ConsulClient();
             var sessionRequest = client.Session.Create(new SessionEntry() { TTL = TimeSpan.FromSeconds(500) });
 
             var id = sessionRequest.Response;
@@ -151,7 +151,7 @@ namespace Consul.Test
 
             try
             {
-                var renewTask = client.Session.RenewPeriodic(TimeSpan.FromSeconds(1), id, WriteOptions.Empty, ct);
+                var renewTask = client.Session.RenewPeriodic(TimeSpan.FromSeconds(1), id, WriteOptions.Default, ct);
                 Assert.True(client.Session.Destroy(id).Response);
                 renewTask.Wait(1000);
             }
@@ -174,7 +174,7 @@ namespace Consul.Test
         [Fact]
         public void Session_Info()
         {
-            var client = new Client();
+            var client = new ConsulClient();
             var sessionRequest = client.Session.Create();
 
             var id = sessionRequest.Response;
@@ -207,7 +207,7 @@ namespace Consul.Test
         [Fact]
         public void Session_Node()
         {
-            var client = new Client();
+            var client = new ConsulClient();
             var sessionRequest = client.Session.Create();
 
             var id = sessionRequest.Response;
@@ -232,7 +232,7 @@ namespace Consul.Test
         [Fact]
         public void Session_List()
         {
-            var client = new Client();
+            var client = new ConsulClient();
             var sessionRequest = client.Session.Create();
 
             var id = sessionRequest.Response;

--- a/Consul.Test/StatusTest.cs
+++ b/Consul.Test/StatusTest.cs
@@ -25,7 +25,7 @@ namespace Consul.Test
         [Fact]
         public void Status_Leader()
         {
-            var client = new Client();
+            var client = new ConsulClient();
             var leader = client.Status.Leader();
             Assert.False(string.IsNullOrEmpty(leader));
         }
@@ -33,7 +33,7 @@ namespace Consul.Test
         [Fact]
         public void Status_Peers()
         {
-            var client = new Client();
+            var client = new ConsulClient();
             var peers = client.Status.Peers();
             Assert.True(peers.Length > 0);
         }

--- a/Consul/ACL.cs
+++ b/Consul/ACL.cs
@@ -153,9 +153,9 @@ namespace Consul
     /// </summary>
     public class ACL : IACLEndpoint
     {
-        private readonly Client _client;
+        private readonly ConsulClient _client;
 
-        internal ACL(Client c)
+        internal ACL(ConsulClient c)
         {
             _client = c;
         }
@@ -173,7 +173,7 @@ namespace Consul
         /// <returns>A write result containing the newly created ACL token</returns>
         public WriteResult<string> Create(ACLEntry acl)
         {
-            return Create(acl, WriteOptions.Empty);
+            return Create(acl, WriteOptions.Default);
         }
 
         /// <summary>
@@ -199,7 +199,7 @@ namespace Consul
         /// <returns>An empty write result</returns>
         public WriteResult Update(ACLEntry acl)
         {
-            return Update(acl, WriteOptions.Empty);
+            return Update(acl, WriteOptions.Default);
         }
 
         /// <summary>
@@ -210,7 +210,7 @@ namespace Consul
         /// <returns>An empty write result</returns>
         public WriteResult Update(ACLEntry acl, WriteOptions q)
         {
-            return _client.CreateInWrite<ACLEntry>("/v1/acl/update", acl, q).Execute();
+            return _client.Put<ACLEntry>("/v1/acl/update", acl, q).Execute();
         }
 
         /// <summary>
@@ -220,7 +220,7 @@ namespace Consul
         /// <returns>An empty write result</returns>
         public WriteResult<bool> Destroy(string id)
         {
-            return Destroy(id, WriteOptions.Empty);
+            return Destroy(id, WriteOptions.Default);
         }
 
         /// <summary>
@@ -231,7 +231,7 @@ namespace Consul
         /// <returns>An empty write result</returns>
         public WriteResult<bool> Destroy(string id, WriteOptions q)
         {
-            return _client.CreateOutWrite<bool>(string.Format("/v1/acl/destroy/{0}", id)).Execute();
+            return _client.EmptyPut<bool>(string.Format("/v1/acl/destroy/{0}", id), q).Execute();
         }
 
         /// <summary>
@@ -241,7 +241,7 @@ namespace Consul
         /// <returns>A write result containing the newly created ACL token</returns>
         public WriteResult<string> Clone(string id)
         {
-            return Clone(id, WriteOptions.Empty);
+            return Clone(id, WriteOptions.Default);
         }
 
         /// <summary>
@@ -252,7 +252,7 @@ namespace Consul
         /// <returns>A write result containing the newly created ACL token</returns>
         public WriteResult<string> Clone(string id, WriteOptions q)
         {
-            var res = _client.CreateOutWrite<ACLCreationResult>(string.Format("/v1/acl/clone/{0}", id), q).Execute();
+            var res = _client.EmptyPut<ACLCreationResult>(string.Format("/v1/acl/clone/{0}", id), q).Execute();
             var ret = new WriteResult<string>
             {
                 RequestTime = res.RequestTime,
@@ -289,7 +289,7 @@ namespace Consul
         /// <returns>A query result containing the ACL entry matching the provided ID, or a query result with a null response if no token matched the provided ID</returns>
         public QueryResult<ACLEntry> Info(string id, QueryOptions q, CancellationToken ct)
         {
-            var res = _client.CreateQuery<ACLEntry[]>(string.Format("/v1/acl/info/{0}", id), q).Execute(ct);
+            var res = _client.Get<ACLEntry[]>(string.Format("/v1/acl/info/{0}", id), q).Execute(ct);
             var ret = new QueryResult<ACLEntry>()
             {
                 KnownLeader = res.KnownLeader,
@@ -329,11 +329,11 @@ namespace Consul
         /// <returns>A write result containing the list of all ACLs</returns>
         public QueryResult<ACLEntry[]> List(QueryOptions q, CancellationToken ct)
         {
-            return _client.CreateQuery<ACLEntry[]>("/v1/acl/list", q).Execute(ct);
+            return _client.Get<ACLEntry[]>("/v1/acl/list", q).Execute(ct);
         }
     }
 
-    public partial class Client : IConsulClient
+    public partial class ConsulClient : IConsulClient
     {
         private ACL _acl;
 

--- a/Consul/Agent.cs
+++ b/Consul/Agent.cs
@@ -440,7 +440,7 @@ namespace Consul
         {
             var request = _client.Put(string.Format("/v1/agent/check/{0}/{1}", status.Status, checkID));
             if (!string.IsNullOrEmpty(note))
-                request.Params.Add("note", HttpUtility.UrlPathEncode(note));
+                request.Params.Add("note", Uri.EscapeDataString(note));
             return request.Execute();
         }
 

--- a/Consul/Agent.cs
+++ b/Consul/Agent.cs
@@ -310,12 +310,12 @@ namespace Consul
     /// </summary>
     public class Agent : IAgentEndpoint
     {
-        private readonly Client _client;
+        private readonly ConsulClient _client;
 
         // cache the node name
         private string _nodeName;
 
-        internal Agent(Client c)
+        internal Agent(ConsulClient c)
         {
             _client = c;
         }
@@ -326,7 +326,7 @@ namespace Consul
         /// <returns>A somewhat dynamic object representing the various data elements in Self</returns>
         public QueryResult<Dictionary<string, Dictionary<string, dynamic>>> Self()
         {
-            return _client.CreateQuery<Dictionary<string, Dictionary<string, dynamic>>>("/v1/agent/self")
+            return _client.Get<Dictionary<string, Dictionary<string, dynamic>>>("/v1/agent/self")
                         .Execute();
         }
 
@@ -352,7 +352,7 @@ namespace Consul
         /// <returns>A map of the registered check names and check data</returns>
         public QueryResult<Dictionary<string, AgentCheck>> Checks()
         {
-            return _client.CreateQuery<Dictionary<string, AgentCheck>>("/v1/agent/checks").Execute();
+            return _client.Get<Dictionary<string, AgentCheck>>("/v1/agent/checks").Execute();
         }
 
         /// <summary>
@@ -361,7 +361,7 @@ namespace Consul
         /// <returns>A map of the registered services and service data</returns>
         public QueryResult<Dictionary<string, AgentService>> Services()
         {
-            var req = _client.CreateQuery<Dictionary<string, AgentService>>("/v1/agent/services").Execute();
+            var req = _client.Get<Dictionary<string, AgentService>>("/v1/agent/services").Execute();
             return req;
         }
 
@@ -371,7 +371,7 @@ namespace Consul
         /// <returns>An array of gossip peers</returns>
         public QueryResult<AgentMember[]> Members(bool wan)
         {
-            var req = _client.CreateQuery<AgentMember[]>("/v1/agent/members");
+            var req = _client.Get<AgentMember[]>("/v1/agent/members");
             if (wan)
             {
                 req.Params["wan"] = "1";
@@ -386,7 +386,7 @@ namespace Consul
         /// <returns>An empty write result</returns>
         public WriteResult ServiceRegister(AgentServiceRegistration service)
         {
-            return _client.CreateInWrite<AgentServiceRegistration>("/v1/agent/service/register", service).Execute();
+            return _client.Put<AgentServiceRegistration>("/v1/agent/service/register", service).Execute();
         }
 
         /// <summary>
@@ -396,7 +396,7 @@ namespace Consul
         /// <returns>An empty write result</returns>
         public WriteResult ServiceDeregister(string serviceID)
         {
-            return _client.CreateWrite(string.Format("/v1/agent/service/deregister/{0}", serviceID)).Execute();
+            return _client.Put(string.Format("/v1/agent/service/deregister/{0}", serviceID)).Execute();
         }
 
         /// <summary>
@@ -438,7 +438,7 @@ namespace Consul
         /// <returns>An empty write result</returns>
         public WriteResult UpdateTTL(string checkID, string note, TTLStatus status)
         {
-            var request = _client.CreateWrite(string.Format("/v1/agent/check/{0}/{1}", status.Status, checkID));
+            var request = _client.Put(string.Format("/v1/agent/check/{0}/{1}", status.Status, checkID));
             if (!string.IsNullOrEmpty(note))
                 request.Params.Add("note", HttpUtility.UrlPathEncode(note));
             return request.Execute();
@@ -451,7 +451,7 @@ namespace Consul
         /// <returns>An empty write result</returns>
         public WriteResult CheckRegister(AgentCheckRegistration check)
         {
-            return _client.CreateInWrite<AgentCheckRegistration>("/v1/agent/check/register", check)
+            return _client.Put<AgentCheckRegistration>("/v1/agent/check/register", check)
                         .Execute();
         }
 
@@ -462,7 +462,7 @@ namespace Consul
         /// <returns>An empty write result</returns>
         public WriteResult CheckDeregister(string checkID)
         {
-            return _client.CreateWrite(string.Format("/v1/agent/check/deregister/{0}", checkID))
+            return _client.Put(string.Format("/v1/agent/check/deregister/{0}", checkID))
                         .Execute();
         }
 
@@ -474,7 +474,7 @@ namespace Consul
         /// <returns>An empty write result</returns>
         public WriteResult Join(string addr, bool wan)
         {
-            var req = _client.CreateWrite(string.Format("/v1/agent/join/{0}", addr));
+            var req = _client.Put(string.Format("/v1/agent/join/{0}", addr));
             if (wan)
             {
                 req.Params["wan"] = "1";
@@ -489,7 +489,7 @@ namespace Consul
         /// <returns>An empty write result</returns>
         public WriteResult ForceLeave(string node)
         {
-            return _client.CreateWrite(string.Format("/v1/agent/force-leave/{0}", node))
+            return _client.Put(string.Format("/v1/agent/force-leave/{0}", node))
                         .Execute();
         }
 
@@ -501,7 +501,7 @@ namespace Consul
         /// <returns>An empty write result</returns>
         public WriteResult EnableServiceMaintenance(string serviceID, string reason)
         {
-            var req = _client.CreateWrite(string.Format("/v1/agent/service/maintenance/{0}", serviceID));
+            var req = _client.Put(string.Format("/v1/agent/service/maintenance/{0}", serviceID));
             req.Params["enable"] = "true";
             req.Params["reason"] = reason;
             return req.Execute();
@@ -514,7 +514,7 @@ namespace Consul
         /// <returns>An empty write result</returns>
         public WriteResult DisableServiceMaintenance(string serviceID)
         {
-            var req = _client.CreateWrite(string.Format("/v1/agent/service/maintenance/{0}", serviceID));
+            var req = _client.Put(string.Format("/v1/agent/service/maintenance/{0}", serviceID));
             req.Params["enable"] = "false";
             return req.Execute();
         }
@@ -526,7 +526,7 @@ namespace Consul
         /// <returns>An empty write result</returns>
         public WriteResult EnableNodeMaintenance(string reason)
         {
-            var req = _client.CreateWrite("/v1/agent/maintenance");
+            var req = _client.Put("/v1/agent/maintenance");
             req.Params["enable"] = "true";
             req.Params["reason"] = reason;
             return req.Execute();
@@ -538,13 +538,13 @@ namespace Consul
         /// <returns>An empty write result</returns>
         public WriteResult DisableNodeMaintenance()
         {
-            var req = _client.CreateWrite("/v1/agent/maintenance");
+            var req = _client.Put("/v1/agent/maintenance");
             req.Params["enable"] = "false";
             return req.Execute();
         }
     }
 
-    public partial class Client : IConsulClient
+    public partial class ConsulClient : IConsulClient
     {
         private Agent _agent;
 

--- a/Consul/Catalog.cs
+++ b/Consul/Catalog.cs
@@ -76,9 +76,9 @@ namespace Consul
     /// </summary>
     public class Catalog : ICatalogEndpoint
     {
-        private readonly Client _client;
+        private readonly ConsulClient _client;
 
-        internal Catalog(Client c)
+        internal Catalog(ConsulClient c)
         {
             _client = c;
         }
@@ -90,7 +90,7 @@ namespace Consul
         /// <returns>An empty write result</returns>
         public WriteResult Register(CatalogRegistration reg)
         {
-            return Register(reg, WriteOptions.Empty);
+            return Register(reg, WriteOptions.Default);
         }
 
         /// <summary>
@@ -102,7 +102,7 @@ namespace Consul
         public WriteResult Register(CatalogRegistration reg, WriteOptions q)
         {
             return
-                _client.CreateInWrite<CatalogRegistration>("/v1/catalog/register", reg, q).Execute();
+                _client.Put<CatalogRegistration>("/v1/catalog/register", reg, q).Execute();
         }
 
         /// <summary>
@@ -112,7 +112,7 @@ namespace Consul
         /// <returns>An empty write result</returns>
         public WriteResult Deregister(CatalogDeregistration reg)
         {
-            return Deregister(reg, WriteOptions.Empty);
+            return Deregister(reg, WriteOptions.Default);
         }
 
         /// <summary>
@@ -123,7 +123,7 @@ namespace Consul
         /// <returns>An empty write result</returns>
         public WriteResult Deregister(CatalogDeregistration reg, WriteOptions q)
         {
-            return _client.CreateInWrite<CatalogDeregistration>("/v1/catalog/deregister", reg, q)
+            return _client.Put<CatalogDeregistration>("/v1/catalog/deregister", reg, q)
                         .Execute();
         }
 
@@ -133,7 +133,7 @@ namespace Consul
         /// <returns>A list of datacenter names</returns>
         public QueryResult<string[]> Datacenters()
         {
-            return _client.CreateQuery<string[]>("/v1/catalog/datacenters").Execute();
+            return _client.Get<string[]>("/v1/catalog/datacenters").Execute();
         }
 
         /// <summary>
@@ -160,7 +160,7 @@ namespace Consul
         /// <returns>A list of all nodes</returns>
         public QueryResult<Node[]> Nodes(QueryOptions q, CancellationToken ct)
         {
-            return _client.CreateQuery<Node[]>("/v1/catalog/nodes", q).Execute(ct);
+            return _client.Get<Node[]>("/v1/catalog/nodes", q).Execute(ct);
         }
 
         /// <summary>
@@ -188,7 +188,7 @@ namespace Consul
         /// <returns>A list of all services</returns>
         public QueryResult<Dictionary<string, string[]>> Services(QueryOptions q, CancellationToken ct)
         {
-            return _client.CreateQuery<Dictionary<string, string[]>>("/v1/catalog/services", q).Execute(ct);
+            return _client.Get<Dictionary<string, string[]>>("/v1/catalog/services", q).Execute(ct);
         }
 
         /// <summary>
@@ -221,7 +221,7 @@ namespace Consul
         /// <returns>A list of service instances</returns>
         public QueryResult<CatalogService[]> Service(string service, string tag, QueryOptions q)
         {
-            var req = _client.CreateQuery<CatalogService[]>(string.Format("/v1/catalog/service/{0}", service), q);
+            var req = _client.Get<CatalogService[]>(string.Format("/v1/catalog/service/{0}", service), q);
             if (!string.IsNullOrEmpty(tag))
             {
                 req.Params["tag"] = tag;
@@ -248,11 +248,11 @@ namespace Consul
         public QueryResult<CatalogNode> Node(string node, QueryOptions q)
         {
             return
-                _client.CreateQuery<CatalogNode>(string.Format("/v1/catalog/node/{0}", node), q).Execute();
+                _client.Get<CatalogNode>(string.Format("/v1/catalog/node/{0}", node), q).Execute();
         }
     }
 
-    public partial class Client : IConsulClient
+    public partial class ConsulClient : IConsulClient
     {
         private Catalog _catalog;
 

--- a/Consul/Client.cs
+++ b/Consul/Client.cs
@@ -24,7 +24,6 @@ using System.IO;
 using System.Net;
 using System.Net.Http;
 using System.Threading;
-using System.Web;
 using Newtonsoft.Json;
 using System.Threading.Tasks;
 using System.Net.Http.Headers;

--- a/Consul/Client.cs
+++ b/Consul/Client.cs
@@ -27,42 +27,72 @@ using System.Threading;
 using System.Web;
 using Newtonsoft.Json;
 using System.Threading.Tasks;
+using System.Net.Http.Headers;
+using System.Linq;
 
 namespace Consul
 {
-    [Serializable]
+    /// <summary>
+    /// Represents errors that occur while sending data to or fetching data from the Consul agent.
+    /// </summary>
     public class ConsulRequestException : Exception
     {
         public ConsulRequestException() { }
         public ConsulRequestException(string message) : base(message) { }
         public ConsulRequestException(string message, Exception inner) : base(message, inner) { }
-        protected ConsulRequestException(
-          System.Runtime.Serialization.SerializationInfo info,
-          System.Runtime.Serialization.StreamingContext context)
-            : base(info, context) { }
     }
 
+    /// <summary>
+    /// Represents errors that occur during initalization of the Consul client's configuration.
+    /// </summary>
+    public class ConsulConfigurationException : Exception
+    {
+        public ConsulConfigurationException() { }
+        public ConsulConfigurationException(string message) : base(message) { }
+        public ConsulConfigurationException(string message, Exception inner) : base(message, inner) { }
+    }
+
+    /// <summary>
+    /// Represents the configuration options for a Consul client.
+    /// </summary>
     public class ConsulClientConfiguration
     {
+        private NetworkCredential _httpauth;
         /// <summary>
-        /// Address is the address of the Consul server
+        /// The Uri to connect to the Consul agent.
         /// </summary>
-        public string Address { get; set; }
+        public Uri Address { get; set; }
 
         /// <summary>
-        /// Scheme is the URI scheme for the Consul server
-        /// </summary>
-        public string Scheme { get; set; }
-
-        /// <summary>
-        /// Datacenter to use. If not provided, the default agent datacenter is used.
+        /// Datacenter to provide with each request. If not provided, the default agent datacenter is used.
         /// </summary>
         public string Datacenter { get; set; }
 
         /// <summary>
-        /// HttpAuth is the auth info to use for http access.
+        /// Credentials to use for access to the HTTP API.
+        /// This is only needed if an authenticating service exists in front of Consul; Token is used for ACL authentication by Consul.
         /// </summary>
-        public NetworkCredential HttpAuth { get; set; }
+        public NetworkCredential HttpAuth
+        {
+            internal get
+            {
+                return _httpauth;
+            }
+            set
+            {
+                _httpauth = value;
+                if (_httpauth != null)
+                {
+                    (Handler as WebRequestHandler).Credentials = _httpauth;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Token is used to provide an ACL token which overrides the agent's default token. This ACL token is used for every request by
+        /// clients created using this configuration.
+        /// </summary>
+        public string Token { get; set; }
 
         /// <summary>
         /// WaitTime limits how long a Watch will block. If not provided, the agent default values will be used.
@@ -70,75 +100,107 @@ namespace Consul
         public TimeSpan? WaitTime { get; set; }
 
         /// <summary>
-        /// Token is used to provide a per-request ACL token which overrides the agent's default token.
+        /// A handler used to bypass HTTPS certificate validation if validation is disabled.
         /// </summary>
-        public string Token { get; set; }
+        internal HttpMessageHandler Handler;
 
         /// <summary>
-        /// Constructs a default configuration for the client
+        /// Creates a new instance of a Consul client configuration.
         /// </summary>
+        /// <exception cref="ConsulConfigurationException">An error that occured while building the configuration.</exception>
         public ConsulClientConfiguration()
         {
-            Address = "127.0.0.1:8500";
-            Scheme = "http";
+            UriBuilder consulAddress = new UriBuilder("http://127.0.0.1:8500");
+            Handler = new WebRequestHandler();
+            ConfigureFromEnvironment(consulAddress);
 
-            if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("CONSUL_HTTP_ADDR")))
+            Address = consulAddress.Uri;
+        }
+
+        /// <summary>
+        /// Builds configuration based on environment variables.
+        /// </summary>
+        /// <exception cref="ConsulConfigurationException">An environment variable could not be parsed</exception>
+        private void ConfigureFromEnvironment(UriBuilder consulAddress)
+        {
+            var envAddr = (Environment.GetEnvironmentVariable("CONSUL_HTTP_ADDR") ?? string.Empty).Trim().ToLowerInvariant();
+            if (!string.IsNullOrEmpty(envAddr))
             {
-                Address = Environment.GetEnvironmentVariable("CONSUL_HTTP_ADDR");
+                var addrParts = envAddr.Split(':');
+                for (int i = 0; i < addrParts.Length; i++)
+                {
+                    addrParts[i] = addrParts[i].Trim();
+                }
+                if (!string.IsNullOrEmpty(addrParts[0]))
+                {
+                    consulAddress.Host = addrParts[0];
+                }
+                if (!string.IsNullOrEmpty(addrParts[1]))
+                {
+                    try
+                    {
+                        consulAddress.Port = ushort.Parse(addrParts[1]);
+                    }
+                    catch (Exception ex)
+                    {
+                        throw new ConsulConfigurationException("Failed parsing port from environment variable CONSUL_HTTP_ADDR", ex);
+                    }
+                }
+            }
+
+            var useSsl = (Environment.GetEnvironmentVariable("CONSUL_HTTP_SSL") ?? string.Empty).Trim().ToLowerInvariant();
+            if (!string.IsNullOrEmpty(useSsl))
+            {
+                try
+                {
+                    if (useSsl == "1" || bool.Parse(useSsl))
+                    {
+                        consulAddress.Scheme = "https";
+                    }
+                }
+                catch (Exception ex)
+                {
+                    throw new ConsulConfigurationException("Could not parse environment variable CONSUL_HTTP_SSL", ex);
+                }
+            }
+
+            var verifySsl = (Environment.GetEnvironmentVariable("CONSUL_HTTP_SSL_VERIFY") ?? string.Empty).Trim().ToLowerInvariant();
+            if (!string.IsNullOrEmpty(verifySsl))
+            {
+                try
+                {
+                    if (verifySsl == "0" || bool.Parse(verifySsl))
+                    {
+                        (Handler as WebRequestHandler).ServerCertificateValidationCallback +=
+                            (sender, cert, chain, sslPolicyErrors) => true;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    throw new ConsulConfigurationException("Could not parse environment variable CONSUL_HTTP_SSL_VERIFY", ex);
+                }
+            }
+
+            var auth = Environment.GetEnvironmentVariable("CONSUL_HTTP_AUTH");
+            if (!string.IsNullOrEmpty(auth))
+            {
+                var credential = new NetworkCredential();
+                if (auth.Contains(":"))
+                {
+                    var split = auth.Split(':');
+                    credential.UserName = split[0];
+                    credential.Password = split[1];
+                }
+                else
+                {
+                    credential.UserName = auth;
+                }
+                HttpAuth = credential;
             }
 
             if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("CONSUL_HTTP_TOKEN")))
             {
                 Token = Environment.GetEnvironmentVariable("CONSUL_HTTP_TOKEN");
-            }
-
-            var consulHttpAuth = Environment.GetEnvironmentVariable("CONSUL_HTTP_AUTH");
-            if (!string.IsNullOrEmpty(consulHttpAuth))
-            {
-                HttpAuth = new NetworkCredential();
-                if (consulHttpAuth.Contains(":"))
-                {
-                    var split = consulHttpAuth.Split(':');
-                    HttpAuth.UserName = split[0];
-                    HttpAuth.Password = split[1];
-                }
-                else
-                {
-                    HttpAuth.UserName = consulHttpAuth;
-                }
-            }
-
-            var consulHttpSsl = Environment.GetEnvironmentVariable("CONSUL_HTTP_SSL");
-            if (!string.IsNullOrEmpty(consulHttpSsl))
-            {
-                try
-                {
-                    if (consulHttpSsl == "1" || bool.Parse(consulHttpSsl))
-                    {
-                        Scheme = "https";
-                    }
-                }
-                catch (Exception)
-                {
-                    throw new ArgumentException("Could not parse environment CONSUL_HTTP_SSL");
-                }
-            }
-
-            var consulHttpSslVerify = Environment.GetEnvironmentVariable("CONSUL_HTTP_SSL_VERIFY");
-            if (!string.IsNullOrEmpty(consulHttpSslVerify))
-            {
-                try
-                {
-                    if (consulHttpSslVerify == "0" || bool.Parse(consulHttpSslVerify))
-                    {
-                        ServicePointManager.ServerCertificateValidationCallback +=
-                            (sender, certificate, chain, errors) => true;
-                    }
-                }
-                catch (Exception)
-                {
-                    throw new ArgumentException("Could not parse environment CONSUL_HTTP_SSL_VERIFY");
-                }
             }
         }
     }
@@ -218,7 +280,7 @@ namespace Consul
     /// </summary>
     public class WriteOptions
     {
-        public static readonly WriteOptions Empty = new WriteOptions()
+        public static readonly WriteOptions Default = new WriteOptions()
         {
             Datacenter = string.Empty,
             Token = string.Empty
@@ -237,9 +299,14 @@ namespace Consul
     public abstract class ConsulResult
     {
         /// <summary>
-        /// How long did the request take
+        /// How long the request took
         /// </summary>
         public TimeSpan RequestTime { get; set; }
+
+        /// <summary>
+        /// Exposed so that the consumer can to check for a specific status code
+        /// </summary>
+        public HttpStatusCode StatusCode { get; set; }
     }
     /// <summary>
     /// The result of a Consul API query
@@ -293,66 +360,205 @@ namespace Consul
     }
 
     /// <summary>
-    /// A query to the Consul service
+    /// Represents a persistant connection to a Consul agent. Instances of this class should be created rarely and reused often.
     /// </summary>
-    /// <typeparam name="T">Must be JSON deserializable. Some writes return nothing, in which case this should be an empty Object</typeparam>
-    public class Query : Request
+    public partial class ConsulClient
     {
-        private QueryResult result;
-        /// <summary>
-        /// Annotate the request with additional query options
-        /// </summary>
-        public QueryOptions Options { get; set; }
+        private object _lock = new object();
+        internal HttpClient HttpClient { get; set; }
+        internal ConsulClientConfiguration Config { get; set; }
 
-        public Query(ConsulClientConfiguration config, HttpMethod method, string path, QueryOptions q)
-            : base(config, method, path)
+        internal readonly JsonSerializer serializer = new JsonSerializer();
+
+        /// <summary>
+        /// Initializes a new Consul client with a default configuration.
+        /// </summary>
+        public ConsulClient() : this(new ConsulClientConfiguration()) { }
+
+        /// <summary>
+        /// Initializes a new Consul client with the configuration specified.
+        /// </summary>
+        /// <param name="config">A Consul client configuration</param>
+        public ConsulClient(ConsulClientConfiguration config)
         {
-            if (q == null)
-            {
-                throw new ArgumentNullException("q");
-            }
-            Options = q;
+            Config = config;
+            HttpClient = new HttpClient(config.Handler);
+            HttpClient.Timeout = TimeSpan.FromMinutes(15);
+            HttpClient.BaseAddress = config.Address;
+            HttpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+            HttpClient.DefaultRequestHeaders.Add("Keep-Alive", "true");
         }
 
-        protected static void ParseQueryHeaders(WebResponse res, QueryResult meta)
+        ~ConsulClient()
         {
-            var headers = res.Headers;
-
-            if (!string.IsNullOrEmpty(headers["X-Consul-Index"]))
+            if (HttpClient != null)
             {
-                try
+                HttpClient.Dispose();
+            }
+        }
+
+        internal GetRequest<T> Get<T>(string path, QueryOptions opts = null)
+        {
+            return new GetRequest<T>(this, path, opts ?? QueryOptions.Default);
+        }
+
+        internal DeleteRequest<T> Delete<T>(string path, WriteOptions opts = null)
+        {
+            return new DeleteRequest<T>(this, path, opts ?? WriteOptions.Default);
+        }
+
+        internal EmptyPutRequest<TOut> EmptyPut<TOut>(string path, WriteOptions opts = null)
+        {
+            return new EmptyPutRequest<TOut>(this, path, opts ?? WriteOptions.Default);
+        }
+
+        internal PutRequest<TIn> Put<TIn>(string path, TIn body, WriteOptions opts = null)
+        {
+            return new PutRequest<TIn>(this, path, body, opts ?? WriteOptions.Default);
+        }
+
+        internal SilentPutRequest Put(string path, WriteOptions opts = null)
+        {
+            return new SilentPutRequest(this, path, opts ?? WriteOptions.Default);
+        }
+
+        internal PutRequest<TIn, TOut> CreateWrite<TIn, TOut>(string path, TIn body, WriteOptions opts = null)
+        {
+            return new PutRequest<TIn, TOut>(this, path, body, opts ?? WriteOptions.Default);
+        }
+    }
+
+    public abstract class ConsulRequest
+    {
+        internal ConsulClient Client { get; set; }
+        internal HttpMethod Method { get; set; }
+        internal Dictionary<string, string> Params { get; set; }
+        internal Stream ResponseStream { get; set; }
+        internal string Endpoint { get; set; }
+
+        protected Stopwatch timer = new Stopwatch();
+
+        internal ConsulRequest(ConsulClient client, string url, HttpMethod method)
+        {
+            Client = client;
+            Method = method;
+            Endpoint = url;
+
+            Params = new Dictionary<string, string>();
+            if (!string.IsNullOrEmpty(client.Config.Datacenter))
+            {
+                Params["dc"] = client.Config.Datacenter;
+            }
+            if (client.Config.WaitTime.HasValue)
+            {
+                Params["wait"] = client.Config.WaitTime.Value.TotalMilliseconds.ToString(CultureInfo.InvariantCulture);
+            }
+            if (!string.IsNullOrEmpty(client.Config.Token))
+            {
+                Params["token"] = client.Config.Token;
+            }
+        }
+
+        protected abstract void ApplyOptions();
+
+        protected Uri BuildConsulUri(string url, Dictionary<string, string> p)
+        {
+            var builder = new UriBuilder(Client.Config.Address);
+            builder.Path = url;
+
+            ApplyOptions();
+
+            var queryParams = new List<string>(Params.Count / 2);
+            foreach (var queryParam in Params)
+            {
+                if (!string.IsNullOrEmpty(queryParam.Value))
                 {
-                    meta.LastIndex = ulong.Parse(headers["X-Consul-Index"]);
+                    queryParams.Add(string.Format("{0}={1}", Uri.EscapeDataString(queryParam.Key),
+                        Uri.EscapeDataString(queryParam.Value)));
                 }
-                catch (Exception ex)
+                else
                 {
-                    throw new ConsulRequestException("Failed to parse X-Consul-Index", ex);
+                    queryParams.Add(string.Format("{0}", Uri.EscapeDataString(queryParam.Key)));
                 }
             }
 
-            if (!string.IsNullOrEmpty(headers["X-Consul-LastContact"]))
+            builder.Query = string.Join("&", queryParams);
+            return builder.Uri;
+        }
+
+        protected TOut Deserialize<TOut>(Stream stream)
+        {
+            using (var reader = new StreamReader(stream))
             {
-                try
+                using (var jsonReader = new JsonTextReader(reader))
                 {
-                    meta.LastContact = TimeSpan.FromMilliseconds(ulong.Parse(headers["X-Consul-LastContact"]));
+                    return Client.serializer.Deserialize<TOut>(jsonReader);
                 }
-                catch (Exception ex)
+            }
+        }
+
+        protected void Serialize(object value, Stream stream)
+        {
+            using (var writer = new StreamWriter(stream))
+            {
+                using (var jsonWriter = new JsonTextWriter(writer))
                 {
-                    throw new ConsulRequestException("Failed to parse X-Consul-LastContact", ex);
+                    Client.serializer.Serialize(jsonWriter, value);
+                    jsonWriter.Flush();
+                }
+            }
+        }
+    }
+    public class GetRequest<T> : ConsulRequest
+    {
+        public QueryOptions Options { get; set; }
+
+        public GetRequest(ConsulClient client, string url, QueryOptions options = null) : base(client, url, HttpMethod.Get)
+        {
+            if (string.IsNullOrEmpty(url))
+            {
+                throw new ArgumentException(url);
+            }
+            Options = options ?? QueryOptions.Default;
+        }
+
+        public QueryResult<T> Execute() { return ExecuteAsync(CancellationToken.None).GetAwaiter().GetResult(); }
+        public QueryResult<T> Execute(CancellationToken ct) { return ExecuteAsync(ct).GetAwaiter().GetResult(); }
+        public async Task<QueryResult<T>> ExecuteAsync() { return await ExecuteAsync(CancellationToken.None).ConfigureAwait(false); }
+        public async Task<QueryResult<T>> ExecuteAsync(CancellationToken ct)
+        {
+            var start = DateTime.UtcNow;
+            var result = new QueryResult<T>();
+
+            var message = new HttpRequestMessage(HttpMethod.Get, BuildConsulUri(Endpoint, Params));
+            var response = await Client.HttpClient.SendAsync(message, ct).ConfigureAwait(false);
+
+            ParseQueryHeaders(response, result);
+            result.StatusCode = response.StatusCode;
+            ResponseStream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+
+            if (response.StatusCode != HttpStatusCode.NotFound && !response.IsSuccessStatusCode)
+            {
+                if (ResponseStream == null)
+                {
+                    throw new ConsulRequestException(string.Format("Unexpected response, status code {0}",
+                        response.StatusCode));
+                }
+                using (var sr = new StreamReader(ResponseStream))
+                {
+                    throw new ConsulRequestException(string.Format("Unexpected response, status code {0}: {1}",
+                        response.StatusCode, sr.ReadToEnd()));
                 }
             }
 
-            if (!string.IsNullOrEmpty(headers["X-Consul-KnownLeader"]))
+            if (response.IsSuccessStatusCode)
             {
-                try
-                {
-                    meta.KnownLeader = bool.Parse(headers["X-Consul-KnownLeader"]);
-                }
-                catch (Exception ex)
-                {
-                    throw new ConsulRequestException("Failed to parse X-Consul-KnownLeader", ex);
-                }
+                result.Response = Deserialize<T>(ResponseStream);
             }
+
+            result.RequestTime = DateTime.UtcNow - start;
+
+            return result;
         }
 
         protected override void ApplyOptions()
@@ -395,127 +601,103 @@ namespace Consul
             }
         }
 
-        protected HttpWebResponse ExecuteInternal<TResult>(TResult result, CancellationToken ct) where TResult : QueryResult
+        protected void ParseQueryHeaders(HttpResponseMessage res, QueryResult<T> meta)
         {
-            var req = BuildWebRequest();
+            var headers = res.Headers;
 
-            timer.Start();
-
-            try
+            if (headers.Contains("X-Consul-Index"))
             {
-                using (ct.Register(() => req.Abort()))
+                try
                 {
-                    var res = (HttpWebResponse)(req.GetResponse());
-                    ReadResponse(res.GetResponseStream(), ref result);
-                    ParseQueryHeaders(res, result);
-                    return res;
+                    meta.LastIndex = ulong.Parse(headers.GetValues("X-Consul-Index").First());
+                }
+                catch (Exception ex)
+                {
+                    throw new ConsulRequestException("Failed to parse X-Consul-Index", ex);
                 }
             }
-            catch (WebException ex)
-            {
-                ct.ThrowIfCancellationRequested();
-                if (ex.Response == null)
-                {
-                    throw new ConsulRequestException("No response from server");
-                }
-                var res = (HttpWebResponse)ex.Response;
-                if (res.StatusCode == HttpStatusCode.NotFound)
-                {
-                    ParseQueryHeaders(res, result);
-                    // Let consumers handle not found since it usually means there was just an empty result from Consul.
-                    throw;
-                }
-                var stream = res.GetResponseStream();
-                if (stream == null)
-                {
-                    throw new ConsulRequestException(string.Format("Unexpected response code {0}",
-                        res.StatusCode));
-                }
-                using (var sr = new StreamReader(stream))
-                {
-                    throw new ConsulRequestException(string.Format("Unexpected response code {0}: {1}",
-                        res.StatusCode, sr.ReadToEnd()));
-                }
-            }
-            finally
-            {
-                result.RequestTime = timer.Elapsed;
-                timer.Stop();
-            }
-        }
 
-        public QueryResult Execute()
-        {
-            return Execute(CancellationToken.None);
-        }
-
-        public QueryResult Execute(CancellationToken ct)
-        {
-            result = new QueryResult();
-            try
+            if (headers.Contains("X-Consul-LastContact"))
             {
-                var response = ExecuteInternal(result, ct);
-                return result;
-            }
-            catch (WebException ex)
-            {
-                if (((HttpWebResponse)ex.Response).StatusCode == HttpStatusCode.NotFound)
+                try
                 {
-                    return result;
+                    meta.LastContact = TimeSpan.FromMilliseconds(ulong.Parse(headers.GetValues("X-Consul-LastContact").First()));
                 }
-                throw;
-            }
-        }
-
-    }    /// <summary>
-    /// A query to the Consul service
-    /// </summary>
-    /// <typeparam name="T">Must be JSON deserializable. Some writes return nothing, in which case this should be an empty Object</typeparam>
-    public class Query<T> : Query
-    {
-        public Query(ConsulClientConfiguration config, HttpMethod method, string path, QueryOptions q)
-            : base(config, method, path, q) { }
-        public new QueryResult<T> Execute()
-        {
-            return Execute(CancellationToken.None);
-        }
-        protected override void ReadResponse<TResult>(Stream responseStream, ref TResult result)
-        {
-            (result as QueryResult<T>).Response = DecodeFromStream<T>(responseStream);
-        }
-
-        public new QueryResult<T> Execute(CancellationToken ct)
-        {
-            var result = new QueryResult<T>();
-            try
-            {
-                var response = ExecuteInternal(result, ct);
-                return result;
-            }
-            catch (WebException ex)
-            {
-                if (((HttpWebResponse)ex.Response).StatusCode == HttpStatusCode.NotFound)
+                catch (Exception ex)
                 {
-                    return result;
+                    throw new ConsulRequestException("Failed to parse X-Consul-LastContact", ex);
                 }
-                throw;
+            }
+
+            if (headers.Contains("X-Consul-KnownLeader"))
+            {
+                try
+                {
+                    meta.KnownLeader = bool.Parse(headers.GetValues("X-Consul-KnownLeader").First());
+                }
+                catch (Exception ex)
+                {
+                    throw new ConsulRequestException("Failed to parse X-Consul-KnownLeader", ex);
+                }
             }
         }
     }
 
-    /// <summary>
-    /// A write to the Consul service
-    /// </summary>
-    public class Write : Request
+    public class DeleteRequest<TOut> : ConsulRequest
     {
-        /// <summary>
-        /// Annotate the request with additional write options
-        /// </summary>
         public WriteOptions Options { get; set; }
+
+        public DeleteRequest(ConsulClient client, string url, WriteOptions options = null) : base(client, url, HttpMethod.Delete)
+        {
+            if (string.IsNullOrEmpty(url))
+            {
+                throw new ArgumentException(url);
+            }
+            Options = options ?? WriteOptions.Default;
+        }
+
+        public WriteResult<TOut> Execute() { return ExecuteAsync().GetAwaiter().GetResult(); }
+        public WriteResult<TOut> Execute(CancellationToken ct) { return ExecuteAsync(ct).GetAwaiter().GetResult(); }
+        public async Task<WriteResult<TOut>> ExecuteAsync() { return await ExecuteAsync(CancellationToken.None).ConfigureAwait(false); }
+        public async Task<WriteResult<TOut>> ExecuteAsync(CancellationToken ct)
+        {
+            timer.Start();
+            var result = new WriteResult<TOut>();
+
+            var response = await Client.HttpClient.DeleteAsync(BuildConsulUri(Endpoint, Params), ct).ConfigureAwait(false);
+
+            result.StatusCode = response.StatusCode;
+
+            ResponseStream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+
+            if (response.StatusCode != HttpStatusCode.NotFound && !response.IsSuccessStatusCode)
+            {
+                if (ResponseStream == null)
+                {
+                    throw new ConsulRequestException(string.Format("Unexpected response, status code {0}",
+                        response.StatusCode));
+                }
+                using (var sr = new StreamReader(ResponseStream))
+                {
+                    throw new ConsulRequestException(string.Format("Unexpected response, status code {0}: {1}",
+                        response.StatusCode, sr.ReadToEnd()));
+                }
+            }
+
+            if (response.IsSuccessStatusCode)
+            {
+                result.Response = Deserialize<TOut>(ResponseStream);
+            }
+
+            result.RequestTime = timer.Elapsed;
+            timer.Stop();
+
+            return result;
+        }
 
         protected override void ApplyOptions()
         {
-            if (Options == WriteOptions.Empty)
+            if (Options == WriteOptions.Default)
             {
                 return;
             }
@@ -529,390 +711,309 @@ namespace Consul
                 Params["token"] = Options.Token;
             }
         }
-        public Write(ConsulClientConfiguration config, HttpMethod method, string path, WriteOptions q)
-            : base(config, method, path)
-        {
-            if (q == null)
-            {
-                throw new ArgumentNullException("q");
-            }
-            Options = q;
-        }
-        protected WriteResult ExecuteInternal(WriteResult result)
-        {
-            var req = BuildWebRequest();
-            HttpWebResponse res;
-            timer.Start();
-            WriteData(req.GetRequestStream());
-            try
-            {
-                res = (HttpWebResponse)req.GetResponse();
-                if (res.StatusCode == HttpStatusCode.OK)
-                {
-                    var stream = res.GetResponseStream();
-                    if (stream != null)
-                        ReadResponse(stream, ref result);
-                }
-            }
-            catch (WebException ex)
-            {
-                res = (HttpWebResponse)ex.Response;
-                if (res.StatusCode == HttpStatusCode.NotFound)
-                {
-                    // Let consumers handle not found since it usually means there was just an empty result from Consul.
-                    throw;
-                }
-                var stream = res.GetResponseStream();
-                if (stream == null)
-                {
-                    throw new ConsulRequestException(string.Format("Unexpected response code {0}",
-                        res.StatusCode));
-                }
-                using (var sr = new StreamReader(stream))
-                {
-                    throw new ConsulRequestException(string.Format("Unexpected response code {0}: {1}",
-                        res.StatusCode, sr.ReadToEnd()));
-                }
-            }
-            finally
-            {
-                result.RequestTime = timer.Elapsed;
-                timer.Stop();
-            }
-            return result;
-        }
-        public virtual WriteResult Execute()
-        {
-            var result = new WriteResult();
-            ExecuteInternal(result);
-            return result;
-        }
     }
 
-    /// <summary>
-    /// A write to the Consul service
-    /// </summary>
-    /// <typeparam name="TIn">The type encoded and sent to Consul. Must be JSON serializable, or a byte[]. If the type is byte[], then it is not JSON encoded before transmission</typeparam>
-    public class Write<TIn> : Write
+    public class EmptyPutRequest<TOut> : ConsulRequest
     {
-        /// <summary>
-        /// The data to write to Consul. Must be serializable to JSON.
-        /// </summary>
-        public TIn RequestBody { get; set; }
+        public WriteOptions Options { get; set; }
 
-        internal bool UseRawRequestBody
+        public EmptyPutRequest(ConsulClient client, string url, WriteOptions options = null) : base(client, url, HttpMethod.Put)
         {
-            get { return GetType().GenericTypeArguments[0] == typeof(byte[]); }
+            if (string.IsNullOrEmpty(url))
+            {
+                throw new ArgumentException(url);
+            }
+            Options = options ?? WriteOptions.Default;
         }
 
-        public Write(ConsulClientConfiguration config, HttpMethod method, string path, TIn body, WriteOptions q)
-            : base(config, method, path, q)
+        public WriteResult<TOut> Execute() { return ExecuteAsync().GetAwaiter().GetResult(); }
+        public WriteResult<TOut> Execute(CancellationToken ct) { return ExecuteAsync(ct).GetAwaiter().GetResult(); }
+        public async Task<WriteResult<TOut>> ExecuteAsync() { return await ExecuteAsync(CancellationToken.None).ConfigureAwait(false); }
+        public async Task<WriteResult<TOut>> ExecuteAsync(CancellationToken ct)
         {
-            RequestBody = body;
-        }
-        public Write(ConsulClientConfiguration config, HttpMethod method, string path, WriteOptions q)
-            : base(config, method, path, q)
-        {
-        }
-        protected override void WriteData(Stream requestStream)
-        {
-            if (UseRawRequestBody)
+            timer.Start();
+            var result = new WriteResult<TOut>();
+
+            var response = await Client.HttpClient.PutAsync(BuildConsulUri(Endpoint, Params), null, ct).ConfigureAwait(false);
+
+            result.StatusCode = response.StatusCode;
+
+            ResponseStream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+
+            if (response.StatusCode != HttpStatusCode.NotFound && !response.IsSuccessStatusCode)
             {
-                WriteRawRequestBody(RequestBody, requestStream);
+                if (ResponseStream == null)
+                {
+                    throw new ConsulRequestException(string.Format("Unexpected response, status code {0}",
+                        response.StatusCode));
+                }
+                using (var sr = new StreamReader(ResponseStream))
+                {
+                    throw new ConsulRequestException(string.Format("Unexpected response, status code {0}: {1}",
+                        response.StatusCode, sr.ReadToEnd()));
+                }
             }
-            else
+
+            if (response.IsSuccessStatusCode)
             {
-                EncodeToStream(RequestBody, requestStream);
+                result.Response = Deserialize<TOut>(ResponseStream);
             }
+
+            result.RequestTime = timer.Elapsed;
+            timer.Stop();
+
+            return result;
         }
-        /// Must be object because T1 cannot be converted to byte[]
-        protected static void WriteRawRequestBody(object body, Stream stream)
+
+        protected override void ApplyOptions()
         {
-            if (body == null)
+            if (Options == WriteOptions.Default)
             {
                 return;
             }
-            var buf = (byte[])body;
-            using (stream)
+
+            if (!string.IsNullOrEmpty(Options.Datacenter))
             {
-                stream.Write(buf, 0, buf.Length);
+                Params["dc"] = Options.Datacenter;
+            }
+            if (!string.IsNullOrEmpty(Options.Token))
+            {
+                Params["token"] = Options.Token;
             }
         }
     }
-    /// <summary>
-    /// A write to the Consul service
-    /// </summary>
-    /// <typeparam name="TIn">The type encoded and sent to Consul. Must be JSON serializable, or a byte[]. If the type is byte[], then it is not JSON encoded before transmission</typeparam>
-    public class Modify<TOut> : Write
+
+    public class SilentPutRequest : ConsulRequest
     {
-        public Modify(ConsulClientConfiguration config, HttpMethod method, string path, WriteOptions q)
-            : base(config, method, path, q) { }
+        public WriteOptions Options { get; set; }
 
-        protected override void ReadResponse<TResult>(Stream responseStream, ref TResult result)
+        public SilentPutRequest(ConsulClient client, string url, WriteOptions options = null) : base(client, url, HttpMethod.Put)
         {
-            (result as WriteResult<TOut>).Response = DecodeFromStream<TOut>(responseStream);
-        }
-
-        public new WriteResult<TOut> Execute()
-        {
-            var result = new WriteResult<TOut>();
-            ExecuteInternal(result);
-            return result;
-        }
-    }
-
-    /// <summary>
-    /// A write to the Consul service
-    /// </summary>
-    /// <typeparam name="TIn">The type encoded and sent to Consul. Must be JSON serializable, or a byte[]. If the type is byte[], then it is not JSON encoded before transmission</typeparam>
-    /// <typeparam name="TOut">The type returned by the write. Must be JSON deserializable. Some writes return nothing, in which case this should be an empty Object</typeparam>
-    public class Write<TIn, TOut> : Write<TIn>
-    {
-        public Write(ConsulClientConfiguration config, HttpMethod method, string path, TIn body, WriteOptions q)
-            : base(config, method, path, body, q) { }
-        public Write(ConsulClientConfiguration config, HttpMethod method, string path, WriteOptions q)
-            : base(config, method, path, q) { }
-
-        protected override void ReadResponse<TResult>(Stream responseStream, ref TResult result)
-        {
-            (result as WriteResult<TOut>).Response = DecodeFromStream<TOut>(responseStream);
-        }
-
-        public new WriteResult<TOut> Execute()
-        {
-            var result = new WriteResult<TOut>();
-            ExecuteInternal(result);
-            return result;
-        }
-    }
-
-    /// <summary>
-    /// A Consul API request
-    /// </summary>
-    public abstract class Request
-    {
-        // 15 minute HTTP timeout
-        protected const int _requestTimeout = 900000;
-
-        protected Stopwatch timer = new Stopwatch();
-        public ConsulClientConfiguration Config { get; set; }
-        public HttpMethod Method { get; set; }
-        public Uri Url { get; set; }
-        public Dictionary<string, string> Params { get; set; }
-        public Stream ResponseStream { get; set; }
-
-        internal Request()
-        {
-            Params = new Dictionary<string, string>();
-        }
-
-        internal Request(ConsulClientConfiguration config, HttpMethod method, string path)
-            : this()
-        {
-            Config = config;
-            Method = method;
-
-            var builder = new UriBuilder { Scheme = config.Scheme };
-            if (config.Address.Contains(":"))
+            if (string.IsNullOrEmpty(url))
             {
-                var split = config.Address.Split(':');
-                try
+                throw new ArgumentException(url);
+            }
+            Options = options ?? WriteOptions.Default;
+        }
+
+        public WriteResult Execute() { return ExecuteAsync().GetAwaiter().GetResult(); }
+        public WriteResult Execute(CancellationToken ct) { return ExecuteAsync(ct).GetAwaiter().GetResult(); }
+        public async Task<WriteResult> ExecuteAsync() { return await ExecuteAsync(CancellationToken.None).ConfigureAwait(false); }
+        public async Task<WriteResult> ExecuteAsync(CancellationToken ct)
+        {
+            timer.Start();
+            var result = new WriteResult();
+
+            var response = await Client.HttpClient.PutAsync(BuildConsulUri(Endpoint, Params), null, ct).ConfigureAwait(false);
+
+            result.StatusCode = response.StatusCode;
+
+            ResponseStream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+
+            if (response.StatusCode != HttpStatusCode.NotFound && !response.IsSuccessStatusCode)
+            {
+                if (ResponseStream == null)
                 {
-                    builder.Host = split[0];
-                    builder.Port = int.Parse(split[1]);
+                    throw new ConsulRequestException(string.Format("Unexpected response, status code {0}",
+                        response.StatusCode));
                 }
-                catch (Exception ex)
+                using (var sr = new StreamReader(ResponseStream))
                 {
-                    throw new ArgumentException("Could not parse port from client config address", ex);
+                    throw new ConsulRequestException(string.Format("Unexpected response, status code {0}: {1}",
+                        response.StatusCode, sr.ReadToEnd()));
                 }
+            }
+
+            result.RequestTime = timer.Elapsed;
+            timer.Stop();
+
+            return result;
+        }
+
+        protected override void ApplyOptions()
+        {
+            if (Options == WriteOptions.Default)
+            {
+                return;
+            }
+
+            if (!string.IsNullOrEmpty(Options.Datacenter))
+            {
+                Params["dc"] = Options.Datacenter;
+            }
+            if (!string.IsNullOrEmpty(Options.Token))
+            {
+                Params["token"] = Options.Token;
+            }
+        }
+    }
+
+    public class PutRequest<TIn> : ConsulRequest
+    {
+        public WriteOptions Options { get; set; }
+        private TIn _body;
+
+        private readonly bool UseRawRequestBody = typeof(TIn) == typeof(byte[]);
+
+        public PutRequest(ConsulClient client, string url, TIn body, WriteOptions options = null) : base(client, url, HttpMethod.Put)
+        {
+            if (string.IsNullOrEmpty(url))
+            {
+                throw new ArgumentException(url);
+            }
+            _body = body;
+            Options = options ?? WriteOptions.Default;
+        }
+
+        public WriteResult Execute() { return ExecuteAsync().GetAwaiter().GetResult(); }
+        public WriteResult Execute(CancellationToken ct) { return ExecuteAsync(ct).GetAwaiter().GetResult(); }
+        public async Task<WriteResult> ExecuteAsync() { return await ExecuteAsync(CancellationToken.None).ConfigureAwait(false); }
+        public async Task<WriteResult> ExecuteAsync(CancellationToken ct)
+        {
+            timer.Start();
+            var result = new WriteResult();
+
+            HttpContent content;
+
+            if (UseRawRequestBody)
+            {
+                content = new ByteArrayContent((_body as byte[]) ?? new byte[0]);
             }
             else
             {
-                builder.Host = config.Address;
+                content = new PushStreamContent((stream, httpContent, transportContext) => { Serialize(_body, stream); });
             }
 
-            builder.Path = path;
+            var response = await Client.HttpClient.PutAsync(BuildConsulUri(Endpoint, Params), content, ct).ConfigureAwait(false);
 
-            if (!string.IsNullOrEmpty(config.Datacenter))
-            {
-                Params["dc"] = config.Datacenter;
-            }
+            result.StatusCode = response.StatusCode;
 
-            if (config.WaitTime.HasValue)
-            {
-                Params["wait"] = config.WaitTime.Value.TotalMilliseconds.ToString(CultureInfo.InvariantCulture);
-            }
+            ResponseStream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
 
-            if (!string.IsNullOrEmpty(config.Token))
+            if (response.StatusCode != HttpStatusCode.NotFound && !response.IsSuccessStatusCode)
             {
-                Params["token"] = config.Token;
-            }
-
-            Url = builder.Uri;
-        }
-        protected virtual void WriteData(Stream requestStream) { }
-        protected virtual void ReadResponse<TResult>(Stream responseStream, ref TResult result) where TResult : ConsulResult { }
-        protected WebRequest BuildWebRequest()
-        {
-            var req = WebRequest.CreateHttp(BuildConsulUri(Url, Params));
-            req.Timeout = _requestTimeout;
-            req.ReadWriteTimeout = _requestTimeout;
-            req.Method = Method.Method;
-            req.Accept = "application/json";
-            req.KeepAlive = true;
-            req.Credentials = Config.HttpAuth;
-            return req;
-        }
-        protected Uri BuildConsulUri(Uri url, Dictionary<string, string> p)
-        {
-            var builder = new UriBuilder(Url);
-            ApplyOptions();
-            var queryParams = new List<string>(Params.Count / 2);
-            foreach (var queryParam in Params)
-            {
-                if (!string.IsNullOrEmpty(queryParam.Value))
+                if (ResponseStream == null)
                 {
-                    queryParams.Add(string.Format("{0}={1}", HttpUtility.UrlPathEncode(queryParam.Key),
-                        HttpUtility.UrlPathEncode(queryParam.Value)));
+                    throw new ConsulRequestException(string.Format("Unexpected response, status code {0}",
+                        response.StatusCode));
                 }
-                else
+                using (var sr = new StreamReader(ResponseStream))
                 {
-                    queryParams.Add(string.Format("{0}", HttpUtility.UrlPathEncode(queryParam.Key)));
+                    throw new ConsulRequestException(string.Format("Unexpected response, status code {0}: {1}",
+                        response.StatusCode, sr.ReadToEnd()));
                 }
             }
-            builder.Query = string.Join("&", queryParams);
-            return builder.Uri;
+
+            result.RequestTime = timer.Elapsed;
+            timer.Stop();
+
+            return result;
         }
 
-        protected abstract void ApplyOptions();
-
-        internal TOut DecodeFromStream<TOut>(Stream stream)
+        protected override void ApplyOptions()
         {
-            using (var reader = new StreamReader(stream))
+            if (Options == WriteOptions.Default)
             {
-                using (var jsonReader = new JsonTextReader(reader))
-                {
-                    var ser = new JsonSerializer();
-                    return ser.Deserialize<TOut>(jsonReader);
-                }
+                return;
             }
-        }
 
-        internal void EncodeToStream(object value, Stream stream)
-        {
-            using (var writer = new StreamWriter(stream))
+            if (!string.IsNullOrEmpty(Options.Datacenter))
             {
-                using (var jsonWriter = new JsonTextWriter(writer))
-                {
-                    var ser = new JsonSerializer();
-                    ser.Serialize(jsonWriter, value);
-                    jsonWriter.Flush();
-                }
+                Params["dc"] = Options.Datacenter;
+            }
+            if (!string.IsNullOrEmpty(Options.Token))
+            {
+                Params["token"] = Options.Token;
             }
         }
     }
 
-    /// <summary>
-    /// Client provides a client to the Consul API. Operations should be done by constructing a client, then using the various APIs from that Client object.
-    /// </summary>
-    public partial class Client : IConsulClient
+    public class PutRequest<TIn, TOut> : ConsulRequest
     {
-        private static readonly object _lock = new object();
-        private readonly ConsulClientConfiguration _config;
+        public WriteOptions Options { get; set; }
+        private TIn _body;
 
-        public Client()
-        {
-            _config = new ConsulClientConfiguration();
-        }
+        private readonly bool UseRawRequestBody = typeof(TIn) == typeof(byte[]);
 
-        public Client(ConsulClientConfiguration c)
+        public PutRequest(ConsulClient client, string url, TIn body, WriteOptions options = null) : base(client, url, HttpMethod.Put)
         {
-            _config = c;
-        }
-        internal Query CreateQuery(string path)
-        {
-            return CreateQuery(HttpMethod.Get, path, QueryOptions.Default);
+            if (string.IsNullOrEmpty(url))
+            {
+                throw new ArgumentException(url);
+            }
+            _body = body;
+            Options = options ?? WriteOptions.Default;
         }
 
-        internal Query CreateQuery(string path, QueryOptions q)
+        public WriteResult<TOut> Execute() { return ExecuteAsync().GetAwaiter().GetResult(); }
+        public WriteResult<TOut> Execute(CancellationToken ct) { return ExecuteAsync(ct).GetAwaiter().GetResult(); }
+        public async Task<WriteResult<TOut>> ExecuteAsync() { return await ExecuteAsync(CancellationToken.None).ConfigureAwait(false); }
+        public async Task<WriteResult<TOut>> ExecuteAsync(CancellationToken ct)
         {
-            return CreateQuery(HttpMethod.Get, path, q);
+            timer.Start();
+            var result = new WriteResult<TOut>();
+
+            HttpContent content = null;
+
+            if (UseRawRequestBody)
+            {
+                if (_body != null)
+                {
+                    content = new ByteArrayContent((_body as byte[]) ?? new byte[0]);
+                }
+                // If body is null and should be a byte array, then just don't send anything.
+            }
+            else
+            {
+                content = new PushStreamContent((stream, httpContent, transportContext) => { Serialize(_body, stream); });
+            }
+
+            var response = await Client.HttpClient.PutAsync(BuildConsulUri(Endpoint, Params), content, ct).ConfigureAwait(false);
+
+            result.StatusCode = response.StatusCode;
+
+            ResponseStream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+
+            if (response.StatusCode != HttpStatusCode.NotFound && !response.IsSuccessStatusCode)
+            {
+                if (ResponseStream == null)
+                {
+                    throw new ConsulRequestException(string.Format("Unexpected response, status code {0}",
+                        response.StatusCode));
+                }
+                using (var sr = new StreamReader(ResponseStream))
+                {
+                    throw new ConsulRequestException(string.Format("Unexpected response, status code {0}: {1}",
+                        response.StatusCode, sr.ReadToEnd()));
+                }
+            }
+
+            if (response.IsSuccessStatusCode)
+            {
+                result.Response = Deserialize<TOut>(ResponseStream);
+            }
+
+            result.RequestTime = timer.Elapsed;
+            timer.Stop();
+
+            return result;
         }
 
-        internal Query CreateQuery(HttpMethod method, string path, QueryOptions q)
+        protected override void ApplyOptions()
         {
-            return new Query(_config, method, path, q);
-        }
-        internal Query<T> CreateQuery<T>(string path)
-        {
-            return CreateQuery<T>(HttpMethod.Get, path, QueryOptions.Default);
-        }
+            if (Options == WriteOptions.Default)
+            {
+                return;
+            }
 
-        internal Query<T> CreateQuery<T>(string path, QueryOptions q)
-        {
-            return CreateQuery<T>(HttpMethod.Get, path, q);
-        }
-
-        internal Query<T> CreateQuery<T>(HttpMethod method, string path, QueryOptions q)
-        {
-            return new Query<T>(_config, method, path, q);
-        }
-        internal Modify<TOut> CreateOutWrite<TOut>(string path)
-        {
-            return CreateOutWrite<TOut>(HttpMethod.Put, path, WriteOptions.Empty);
-        }
-
-        internal Modify<TOut> CreateOutWrite<TOut>(string path, WriteOptions q)
-        {
-            return CreateOutWrite<TOut>(HttpMethod.Put, path, q);
-        }
-
-        internal Modify<TOut> CreateOutWrite<TOut>(HttpMethod method, string path, WriteOptions q)
-        {
-            return new Modify<TOut>(_config, method, path, q);
-        }
-        internal Write<TIn> CreateInWrite<TIn>(string path, TIn body)
-        {
-            return CreateInWrite<TIn>(HttpMethod.Put, path, body, WriteOptions.Empty);
-        }
-
-        internal Write<TIn> CreateInWrite<TIn>(string path, TIn body, WriteOptions q)
-        {
-            return CreateInWrite<TIn>(HttpMethod.Put, path, body, q);
-        }
-
-        internal Write<TIn> CreateInWrite<TIn>(HttpMethod method, string path, TIn body, WriteOptions q)
-        {
-            return new Write<TIn>(_config, method, path, body, q);
-        }
-        internal Write CreateWrite(string path)
-        {
-            return CreateWrite(HttpMethod.Put, path, WriteOptions.Empty);
-        }
-
-        internal Write CreateWrite(string path, WriteOptions q)
-        {
-            return CreateWrite(HttpMethod.Put, path, q);
-        }
-
-        internal Write CreateWrite(HttpMethod method, string path, WriteOptions q)
-        {
-            return new Write(_config, method, path, q);
-        }
-
-        internal Write<TIn, TOut> CreateWrite<TIn, TOut>(string path, TIn body)
-        {
-            return CreateWrite<TIn, TOut>(HttpMethod.Put, path, body, WriteOptions.Empty);
-        }
-
-        internal Write<TIn, TOut> CreateWrite<TIn, TOut>(string path, TIn body, WriteOptions q)
-        {
-            return CreateWrite<TIn, TOut>(HttpMethod.Put, path, body, q);
-        }
-
-        internal Write<TIn, TOut> CreateWrite<TIn, TOut>(HttpMethod method, string path, TIn body, WriteOptions q)
-        {
-            return new Write<TIn, TOut>(_config, method, path, body, q);
+            if (!string.IsNullOrEmpty(Options.Datacenter))
+            {
+                Params["dc"] = Options.Datacenter;
+            }
+            if (!string.IsNullOrEmpty(Options.Token))
+            {
+                Params["token"] = Options.Token;
+            }
         }
     }
 }

--- a/Consul/Consul.csproj
+++ b/Consul/Consul.csproj
@@ -44,16 +44,10 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
-    <Reference Include="System.Core" />
     <Reference Include="System.Net.Http.Formatting, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL" />
     <Reference Include="System.Net.Http.WebRequest" />
-    <Reference Include="System.Web" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
     <Reference Include="System.Net.Http" />
-    <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ACL.cs" />

--- a/Consul/Consul.csproj
+++ b/Consul/Consul.csproj
@@ -45,6 +45,8 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Net.Http.Formatting, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL" />
+    <Reference Include="System.Net.Http.WebRequest" />
     <Reference Include="System.Web" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />

--- a/Consul/Coordinate.cs
+++ b/Consul/Coordinate.cs
@@ -51,9 +51,9 @@ namespace Consul
 
     public class Coordinate : ICoordinateEndpoint
     {
-        private readonly Client _client;
+        private readonly ConsulClient _client;
 
-        internal Coordinate(Client c)
+        internal Coordinate(ConsulClient c)
         {
             _client = c;
         }
@@ -64,7 +64,7 @@ namespace Consul
         /// <returns>A query result containing a map of datacenters, each with a list of coordinates of all the servers in the WAN pool</returns>
         public QueryResult<CoordinateDatacenterMap[]> Datacenters()
         {
-            return _client.CreateQuery<CoordinateDatacenterMap[]>(string.Format("/v1/coordinate/datacenters")).Execute();
+            return _client.Get<CoordinateDatacenterMap[]>(string.Format("/v1/coordinate/datacenters")).Execute();
         }
 
         /// <summary>
@@ -83,11 +83,11 @@ namespace Consul
         /// <returns>A query result containing coordinates of all the nodes in the LAN pool</returns>
         public QueryResult<CoordinateEntry[]> Nodes(QueryOptions q)
         {
-            return _client.CreateQuery<CoordinateEntry[]>(string.Format("/v1/coordinate/nodes"), q).Execute();
+            return _client.Get<CoordinateEntry[]>(string.Format("/v1/coordinate/nodes"), q).Execute();
         }
     }
 
-    public partial class Client : IConsulClient
+    public partial class ConsulClient : IConsulClient
     {
         private Coordinate _coordinate;
 

--- a/Consul/Event.cs
+++ b/Consul/Event.cs
@@ -46,16 +46,16 @@ namespace Consul
             internal string ID { get; set; }
         }
 
-        private readonly Client _client;
+        private readonly ConsulClient _client;
 
-        internal Event(Client c)
+        internal Event(ConsulClient c)
         {
             _client = c;
         }
 
         public WriteResult<string> Fire(UserEvent ue)
         {
-            return Fire(ue, WriteOptions.Empty);
+            return Fire(ue, WriteOptions.Default);
         }
 
         /// <summary>
@@ -129,7 +129,7 @@ namespace Consul
         /// <returns>An array of events</returns>
         public QueryResult<UserEvent[]> List(string name, QueryOptions q, CancellationToken ct)
         {
-            var req = _client.CreateQuery<UserEvent[]>("/v1/event/list", q);
+            var req = _client.Get<UserEvent[]>("/v1/event/list", q);
             if (!string.IsNullOrEmpty(name))
             {
                 req.Params["name"] = name;
@@ -152,7 +152,7 @@ namespace Consul
         }
     }
 
-    public partial class Client : IConsulClient
+    public partial class ConsulClient : IConsulClient
     {
         private Event _event;
 

--- a/Consul/Health.cs
+++ b/Consul/Health.cs
@@ -49,9 +49,9 @@ namespace Consul
     /// </summary>
     public class Health : IHealthEndpoint
     {
-        private readonly Client _client;
+        private readonly ConsulClient _client;
 
-        internal Health(Client c)
+        internal Health(ConsulClient c)
         {
             _client = c;
         }
@@ -84,7 +84,7 @@ namespace Consul
         public QueryResult<HealthCheck[]> Node(string node, QueryOptions q, CancellationToken ct)
         {
             return
-                _client.CreateQuery<HealthCheck[]>(string.Format("/v1/health/node/{0}", node), q).Execute(ct);
+                _client.Get<HealthCheck[]>(string.Format("/v1/health/node/{0}", node), q).Execute(ct);
         }
 
         /// <summary>
@@ -114,7 +114,7 @@ namespace Consul
         /// <returns>A query result containing the health checks matching the provided service ID, or a query result with a null response if no service matched the provided ID</returns>
         public QueryResult<HealthCheck[]> Checks(string service, QueryOptions q, CancellationToken ct)
         {
-            return _client.CreateQuery<HealthCheck[]>(string.Format("/v1/health/checks/{0}", service), q)
+            return _client.Get<HealthCheck[]>(string.Format("/v1/health/checks/{0}", service), q)
                         .Execute(ct);
         }
 
@@ -174,7 +174,7 @@ namespace Consul
         public QueryResult<ServiceEntry[]> Service(string service, string tag, bool passingOnly,
             QueryOptions q, CancellationToken ct)
         {
-            var req = _client.CreateQuery<ServiceEntry[]>(string.Format("/v1/health/service/{0}", service), q);
+            var req = _client.Get<ServiceEntry[]>(string.Format("/v1/health/service/{0}", service), q);
             if (!string.IsNullOrEmpty(tag))
             {
                 req.Params["tag"] = tag;
@@ -215,12 +215,12 @@ namespace Consul
         /// <returns>A query result containing a list of health checks in the specified state, or a query result with a null response if no health checks matched the provided state</returns>
         public QueryResult<HealthCheck[]> State(CheckStatus status, QueryOptions q, CancellationToken ct)
         {
-            return _client.CreateQuery<HealthCheck[]>(string.Format("/v1/health/state/{0}", status.Status), q)
+            return _client.Get<HealthCheck[]>(string.Format("/v1/health/state/{0}", status.Status), q)
                         .Execute(ct);
         }
     }
 
-    public partial class Client : IConsulClient
+    public partial class ConsulClient : IConsulClient
     {
         private Health _health;
 

--- a/Consul/KV.cs
+++ b/Consul/KV.cs
@@ -80,9 +80,9 @@ namespace Consul
     /// </summary>
     public class KV : IKVEndpoint
     {
-        private readonly Client _client;
+        private readonly ConsulClient _client;
 
-        public KV(Client c)
+        public KV(ConsulClient c)
         {
             _client = c;
         }
@@ -115,7 +115,7 @@ namespace Consul
         /// <returns>A query result containing the requested key/value pair, or a query result with a null response if the key does not exist</returns>
         public QueryResult<KVPair> Get(string key, QueryOptions q, CancellationToken ct)
         {
-            var req = _client.CreateQuery<KVPair[]>(string.Format("/v1/kv/{0}", key), q);
+            var req = _client.Get<KVPair[]>(string.Format("/v1/kv/{0}", key), q);
             var res = req.Execute(ct);
             var ret = new QueryResult<KVPair>()
             {
@@ -161,7 +161,7 @@ namespace Consul
         /// <returns></returns>
         public QueryResult<KVPair[]> List(string prefix, QueryOptions q, CancellationToken ct)
         {
-            var req = _client.CreateQuery<KVPair[]>(string.Format("/v1/kv/{0}", prefix), q);
+            var req = _client.Get<KVPair[]>(string.Format("/v1/kv/{0}", prefix), q);
             req.Params["recurse"] = string.Empty;
             return req.Execute(ct);
         }
@@ -209,7 +209,7 @@ namespace Consul
         /// <returns>A query result containing a list of key names</returns>
         public QueryResult<string[]> Keys(string prefix, string separator, QueryOptions q, CancellationToken ct)
         {
-            var req = _client.CreateQuery<string[]>(string.Format("/v1/kv/{0}", prefix), q);
+            var req = _client.Get<string[]>(string.Format("/v1/kv/{0}", prefix), q);
             req.Params["keys"] = string.Empty;
             if (!string.IsNullOrEmpty(separator))
             {
@@ -225,7 +225,7 @@ namespace Consul
         /// <returns>A write result indicating if the write attempt succeeded</returns>
         public WriteResult<bool> Put(KVPair p)
         {
-            return Put(p, WriteOptions.Empty);
+            return Put(p, WriteOptions.Default);
         }
 
         /// <summary>
@@ -252,7 +252,7 @@ namespace Consul
         /// <returns>A write result indicating if the write attempt succeeded</returns>
         public WriteResult<bool> CAS(KVPair p)
         {
-            return CAS(p, WriteOptions.Empty);
+            return CAS(p, WriteOptions.Default);
         }
 
         /// <summary>
@@ -280,7 +280,7 @@ namespace Consul
         /// <returns>A write result indicating if the acquisition attempt succeeded</returns>
         public WriteResult<bool> Acquire(KVPair p)
         {
-            return Acquire(p, WriteOptions.Empty);
+            return Acquire(p, WriteOptions.Default);
         }
 
         /// <summary>
@@ -308,7 +308,7 @@ namespace Consul
         /// <returns>A write result indicating if the release attempt succeeded</returns>
         public WriteResult<bool> Release(KVPair p)
         {
-            return Release(p, WriteOptions.Empty);
+            return Release(p, WriteOptions.Default);
         }
 
         /// <summary>
@@ -336,7 +336,7 @@ namespace Consul
         /// <returns>A write result indicating if the delete attempt succeeded</returns>
         public WriteResult<bool> Delete(string key)
         {
-            return Delete(key, WriteOptions.Empty);
+            return Delete(key, WriteOptions.Default);
         }
 
         /// <summary>
@@ -348,7 +348,7 @@ namespace Consul
         public WriteResult<bool> Delete(string key, WriteOptions q)
         {
             KVPair.ValidatePath(key);
-            return _client.CreateOutWrite<bool>(HttpMethod.Delete, string.Format("/v1/kv/{0}", key), q)
+            return _client.Delete<bool>(string.Format("/v1/kv/{0}", key), q)
                         .Execute();
         }
 
@@ -359,7 +359,7 @@ namespace Consul
         /// <returns>A write result indicating if the delete attempt succeeded</returns>
         public WriteResult<bool> DeleteCAS(KVPair p)
         {
-            return DeleteCAS(p, WriteOptions.Empty);
+            return DeleteCAS(p, WriteOptions.Default);
         }
 
         /// <summary>
@@ -371,7 +371,7 @@ namespace Consul
         public WriteResult<bool> DeleteCAS(KVPair p, WriteOptions q)
         {
             p.Validate();
-            var req = _client.CreateOutWrite<bool>(HttpMethod.Delete, string.Format("/v1/kv/{0}", p.Key), q);
+            var req = _client.Delete<bool>(string.Format("/v1/kv/{0}", p.Key), q);
             req.Params.Add("cas", p.ModifyIndex.ToString());
             return req.Execute();
         }
@@ -383,7 +383,7 @@ namespace Consul
         /// <returns>A write result indicating if the recursive delete attempt succeeded</returns>
         public WriteResult<bool> DeleteTree(string prefix)
         {
-            return DeleteTree(prefix, WriteOptions.Empty);
+            return DeleteTree(prefix, WriteOptions.Default);
         }
 
         /// <summary>
@@ -395,7 +395,7 @@ namespace Consul
         public WriteResult<bool> DeleteTree(string prefix, WriteOptions q)
         {
             KVPair.ValidatePath(prefix);
-            var req = _client.CreateOutWrite<bool>(HttpMethod.Delete, string.Format("/v1/kv/{0}", prefix), q);
+            var req = _client.Delete<bool>(string.Format("/v1/kv/{0}", prefix), q);
             req.Params.Add("recurse", string.Empty);
             return req.Execute();
         }
@@ -404,7 +404,7 @@ namespace Consul
     /// <summary>
     /// KV is used to return a handle to the K/V apis
     /// </summary>
-    public partial class Client : IConsulClient
+    public partial class ConsulClient : IConsulClient
     {
         private KV _kv;
 

--- a/Consul/Lock.cs
+++ b/Consul/Lock.cs
@@ -151,7 +151,7 @@ namespace Consul
         private Task _sessionRenewTask;
         private Task _monitorTask;
 
-        private readonly Client _client;
+        private readonly ConsulClient _client;
         internal LockOptions Opts { get; set; }
         internal string LockSession { get; set; }
 
@@ -179,7 +179,7 @@ namespace Consul
         }
 
 
-        internal Lock(Client c)
+        internal Lock(ConsulClient c)
         {
             _client = c;
             _cts = new CancellationTokenSource();
@@ -232,7 +232,7 @@ namespace Consul
                         {
                             Opts.Session = CreateSession();
                             _sessionRenewTask = _client.Session.RenewPeriodic(Opts.SessionTTL, Opts.Session,
-                                WriteOptions.Empty, _cts.Token);
+                                WriteOptions.Default, _cts.Token);
                             LockSession = Opts.Session;
                         }
                         catch (Exception ex)
@@ -505,7 +505,7 @@ namespace Consul
     public class DisposableLock : Lock, IDisposable, IDisposableLock
     {
         public CancellationToken CancellationToken { get; private set; }
-        internal DisposableLock(Client client, LockOptions opts, CancellationToken ct)
+        internal DisposableLock(ConsulClient client, LockOptions opts, CancellationToken ct)
             : base(client)
         {
             Opts = opts;
@@ -553,7 +553,7 @@ namespace Consul
         }
     }
 
-    public partial class Client : IConsulClient
+    public partial class ConsulClient : IConsulClient
     {
         /// <summary>
         /// CreateLock returns an unlocked lock which can be used to acquire and release the mutex. The key used must have write permissions.

--- a/Consul/Raw.cs
+++ b/Consul/Raw.cs
@@ -25,9 +25,9 @@ namespace Consul
     /// </summary>
     public class Raw : IRawEndpoint
     {
-        private readonly Client _client;
+        private readonly ConsulClient _client;
 
-        internal Raw(Client c)
+        internal Raw(ConsulClient c)
         {
             _client = c;
         }
@@ -52,7 +52,7 @@ namespace Consul
         /// <returns>The data returned by the custom endpoint</returns>
         public  QueryResult<dynamic> Query(string endpoint, QueryOptions q, CancellationToken ct)
         {
-            return _client.CreateQuery<dynamic>(endpoint, q).Execute(ct);
+            return _client.Get<dynamic>(endpoint, q).Execute(ct);
         }
 
         /// <summary>
@@ -68,7 +68,7 @@ namespace Consul
         }
     }
 
-    public partial class Client : IConsulClient
+    public partial class ConsulClient : IConsulClient
     {
         private Raw _raw;
 

--- a/Consul/Semaphore.cs
+++ b/Consul/Semaphore.cs
@@ -223,7 +223,7 @@ namespace Consul
 
         private CancellationTokenSource _cts;
 
-        private readonly Client _client;
+        private readonly ConsulClient _client;
         private Task _sessionRenewTask;
         private Task _monitorTask;
         internal SemaphoreOptions Opts { get; set; }
@@ -248,7 +248,7 @@ namespace Consul
 
         internal string LockSession { get; set; }
 
-        internal Semaphore(Client c)
+        internal Semaphore(ConsulClient c)
         {
             _client = c;
             _cts = new CancellationTokenSource();
@@ -299,7 +299,7 @@ namespace Consul
                         try
                         {
                             Opts.Session = CreateSession();
-                            _sessionRenewTask = _client.Session.RenewPeriodic(Opts.SessionTTL, Opts.Session, WriteOptions.Empty, _cts.Token);
+                            _sessionRenewTask = _client.Session.RenewPeriodic(Opts.SessionTTL, Opts.Session, WriteOptions.Default, _cts.Token);
                             LockSession = Opts.Session;
                         }
                         catch (Exception ex)
@@ -681,7 +681,7 @@ namespace Consul
     public class AutoSemaphore : Semaphore, IDisposable, IDisposableSemaphore
     {
         public CancellationToken CancellationToken { get; private set; }
-        internal AutoSemaphore(Client c, SemaphoreOptions opts)
+        internal AutoSemaphore(ConsulClient c, SemaphoreOptions opts)
             : base(c)
         {
             Opts = opts;
@@ -762,7 +762,7 @@ namespace Consul
         }
     }
 
-    public partial class Client : IConsulClient
+    public partial class ConsulClient : IConsulClient
     {
         /// <summary>
         /// Used to created a Semaphore which will operate at the given KV prefix and uses the given limit for the semaphore.

--- a/Consul/Status.cs
+++ b/Consul/Status.cs
@@ -22,9 +22,9 @@ namespace Consul
 {
     public class Status : IStatusEndpoint
     {
-        private readonly Client _client;
+        private readonly ConsulClient _client;
 
-        internal Status(Client c)
+        internal Status(ConsulClient c)
         {
             _client = c;
         }
@@ -35,7 +35,7 @@ namespace Consul
         /// <returns>A write result containing the leader node name</returns>
         public string Leader()
         {
-            var res = _client.CreateQuery<string>("/v1/status/leader").Execute();
+            var res = _client.Get<string>("/v1/status/leader").Execute();
             return res.Response;
         }
 
@@ -45,12 +45,12 @@ namespace Consul
         /// <returns>A write result containing the list of Raft peers</returns>
         public string[] Peers()
         {
-            var res = _client.CreateQuery<string[]>("/v1/status/peers").Execute();
+            var res = _client.Get<string[]>("/v1/status/peers").Execute();
             return res.Response;
         }
     }
 
-    public partial class Client : IConsulClient
+    public partial class ConsulClient : IConsulClient
     {
         private Status _status;
 


### PR DESCRIPTION
Two big breaking changes:
* The `Client` class has been renamed `ConsulClient`. The interface
  remains the same - `IConsulClient`.
* The `ConsulClientConfiguration` class no longer accepts a string
  `Address` property to the Consul server. It is now a `System.Uri`
  named `Address`.

This PR removes all references to System.Web and replaces the underlying HTTP client that the API uses with System.Net.HttpClient.

@hungwunfai if you have some time to look into this, it would be greatly appreciated if you could pull down the nuget packages from https://ci.appveyor.com/project/highlyunavailable/consuldotnet/build/0.6.0.122-feature/newclient/artifacts and try compiling the PlayFab stuff against them. There's no hurry as I won't be actually merging develop to master until Consul 0.6.0 drops (which should be a couple weeks from the look of their milestone), but I also don't want to break your stuff with no warning.