### PR TITLE
Use ILRepack on release builds to package JSON.net into the Consul dll

### DIFF
--- a/Consul/Consul.csproj
+++ b/Consul/Consul.csproj
@@ -109,20 +109,18 @@
       <OutputFolder>$(ProjectDir)$(OutputPath)Standalone</OutputFolder>
       <FullOutputAssemblyPath>$(OutputFolder)\$(OutputFileName)</FullOutputAssemblyPath>
       <KeyFilePath>$(ProjectDir)$(AssemblyOriginatorKeyFile)</KeyFilePath>
+      <MergerEXEPath>$(ProjectDir)..\packages\ILRepack.2.0.10\tools\ILRepack.exe</MergerEXEPath>
+      <MergerEXE Condition="('$(OS)' == 'Windows_NT')">$(MergerEXEPath)</MergerEXE>
+      <MergerEXE Condition="('$(OS)' != 'Windows_NT')">mono $(MergerEXEPath)</MergerEXE>
+      <MergerCommands>/keyfile:$(KeyFilePath) /parallel /internalize /out:$(FullOutputAssemblyPath) @(InputAssemblies->'%(FullPath)', ' ')</MergerCommands>
     </PropertyGroup>
-    <Message Text="MERGING: @(InputAssemblies->'%(Filename)') into $(FullOutputAssemblyPath)" Importance="High" />
-    <ILRepack KeyFile="$(KeyFilePath)" Parallel="true" Internalize="true" DebugInfo="true" InputAssemblies="@(InputAssemblies)" TargetKind="Dll" OutputFile="$(FullOutputAssemblyPath)" />
+    <Message Text="MERGING: @(InputAssemblies->'%(Filename)') into $(FullOutputAssemblyPath) with the command $(MergerEXE) $(MergerCommands)" Importance="High" />
+    <Exec Command="$(MergerEXE) $(MergerCommands)" WorkingDirectory="$(OutputPath)" />
     <Message Text="DELETING: original files - @(FilesToDelete->'%(Filename)')" Importance="High" />
     <Delete Files="@(FilesToDelete)" />
     <Message Text="COPYING: @(FilesToCopy->'%(Filename)')" Importance="High" />
-    <Exec Command="xcopy /s /y $(OutputFolder)\*.* $(ProjectDir)$(OutputPath)" />
+    <Exec Condition="('$(OS)' == 'Windows_NT')" Command="xcopy /s /y $(OutputFolder)\*.* $(ProjectDir)$(OutputPath)" />
+    <Exec Condition="('$(OS)' != 'Windows_NT')" Command="cp -a $(OutputFolder)/. $(ProjectDir)$(OutputPath)/" />
     <RemoveDir Directories="$(OutputFolder)" />
-  </Target>
-  <Import Project="..\packages\ILRepack.MSBuild.Task.1.0.9\build\ILRepack.MSBuild.Task.targets" Condition="Exists('..\packages\ILRepack.MSBuild.Task.1.0.9\build\ILRepack.MSBuild.Task.targets')" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('..\packages\ILRepack.MSBuild.Task.1.0.9\build\ILRepack.MSBuild.Task.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\ILRepack.MSBuild.Task.1.0.9\build\ILRepack.MSBuild.Task.targets'))" />
   </Target>
 </Project>

--- a/Consul/Consul.csproj
+++ b/Consul/Consul.csproj
@@ -109,17 +109,20 @@
       <OutputFolder>$(ProjectDir)$(OutputPath)Standalone</OutputFolder>
       <FullOutputAssemblyPath>$(OutputFolder)\$(OutputFileName)</FullOutputAssemblyPath>
       <KeyFilePath>$(ProjectDir)$(AssemblyOriginatorKeyFile)</KeyFilePath>
-      <MergerEXEPath>$(SolutionDir)packages\ILRepack.2.0.10\tools\ILRepack.exe</MergerEXEPath>
-      <MergerEXE Condition="('$(OS)' == 'Windows_NT')">$(MergerEXEPath)</MergerEXE>
-      <MergerEXE Condition="('$(OS)' != 'Windows_NT')">mono $(MergerEXEPath)</MergerEXE>
-      <MergerCommands>/keyfile:$(KeyFilePath) /parallel /internalize /out:$(FullOutputAssemblyPath) @(InputAssemblies->'%(FullPath)', ' ')</MergerCommands>
     </PropertyGroup>
-    <Message Text="MERGING: @(InputAssemblies->'%(Filename)') into $(FullOutputAssemblyPath) with the command $(MergerEXE) $(MergerCommands)" Importance="High" />
-    <Exec Command="$(MergerEXE) $(MergerCommands)" WorkingDirectory="$(OutputPath)" />
+    <Message Text="MERGING: @(InputAssemblies->'%(Filename)') into $(FullOutputAssemblyPath)" Importance="High" />
+    <ILRepack KeyFile="$(KeyFilePath)" Parallel="true" Internalize="true" DebugInfo="true" InputAssemblies="@(InputAssemblies)" TargetKind="Dll" OutputFile="$(FullOutputAssemblyPath)" />
     <Message Text="DELETING: original files - @(FilesToDelete->'%(Filename)')" Importance="High" />
     <Delete Files="@(FilesToDelete)" />
     <Message Text="COPYING: @(FilesToCopy->'%(Filename)')" Importance="High" />
     <Exec Command="xcopy /s /y $(OutputFolder)\*.* $(ProjectDir)$(OutputPath)" />
     <RemoveDir Directories="$(OutputFolder)" />
+  </Target>
+  <Import Project="..\packages\ILRepack.MSBuild.Task.1.0.9\build\ILRepack.MSBuild.Task.targets" Condition="Exists('..\packages\ILRepack.MSBuild.Task.1.0.9\build\ILRepack.MSBuild.Task.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\ILRepack.MSBuild.Task.1.0.9\build\ILRepack.MSBuild.Task.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\ILRepack.MSBuild.Task.1.0.9\build\ILRepack.MSBuild.Task.targets'))" />
   </Target>
 </Project>

--- a/Consul/Consul.csproj
+++ b/Consul/Consul.csproj
@@ -109,7 +109,7 @@
       <OutputFolder>$(OutputPath)\Standalone</OutputFolder>
       <OutputAssembly>$(OutputFolder)\$(OutputFileName)</OutputAssembly>
     </PropertyGroup>
-    <ILRepack Parallel="true" Internalize="true" XmlDocumentation="true" DebugInfo="true" InputAssemblies="@(InputAssemblies)" TargetKind="library" OutputFile="$(OutputAssembly)" />
+    <ILRepack KeyFile="$(AssemblyOriginatorKeyFile)" Parallel="true" Internalize="true" XmlDocumentation="true" DebugInfo="true" InputAssemblies="@(InputAssemblies)" TargetKind="Dll" OutputFile="$(OutputAssembly)" />
     <Delete Files="@(FilesToDelete)" />
     <Copy SourceFiles="$(OutputAssembly)" DestinationFolder="$(OutputPath)" />
     <RemoveDir Directories="$(OutputFolder)" />

--- a/Consul/Consul.csproj
+++ b/Consul/Consul.csproj
@@ -100,7 +100,9 @@
     <ItemGroup>
       <InputAssemblies Include="$(OutputPath)\$(AssemblyName).dll" />
       <InputAssemblies Include="$(OutputPath)\Newtonsoft.Json.dll" />
-      <FilesToDelete Include="$(OutputPath)\*.*" />
+      <FilesToDelete Include="@(InputAssemblies)" />
+      <FilesToDelete Include="$(OutputPath)\Consul.pdb" />
+      <FilesToDelete Include="$(OutputPath)\Newtonsoft.Json.xml" />
     </ItemGroup>
     <PropertyGroup>
       <OutputFileName>$(AssemblyName).dll</OutputFileName>

--- a/Consul/Consul.csproj
+++ b/Consul/Consul.csproj
@@ -96,4 +96,27 @@
   <Target Name="AfterBuild">
   </Target>
   -->
+  <Target Name="AfterBuild" Condition="'$(Configuration)' == 'Release'">
+    <ItemGroup>
+      <InputAssemblies Include="$(OutputPath)\$(AssemblyName).dll" />
+      <InputAssemblies Include="$(OutputPath)\Newtonsoft.Json.dll" />
+      <FilesToDelete Include="$(OutputPath)\*.*" />
+    </ItemGroup>
+    <PropertyGroup>
+      <OutputFileName>$(AssemblyName).dll</OutputFileName>
+      <OutputFolder>$(OutputPath)\Standalone</OutputFolder>
+      <OutputAssembly>$(OutputFolder)\$(OutputFileName)</OutputAssembly>
+    </PropertyGroup>
+    <ILRepack Parallel="true" Internalize="true" InputAssemblies="@(InputAssemblies)" TargetKind="library" OutputFile="$(OutputAssembly)" />
+    <Delete Files="@(FilesToDelete)" />
+    <Copy SourceFiles="$(OutputAssembly)" DestinationFolder="$(OutputPath)" />
+    <RemoveDir Directories="$(OutputFolder)" />
+  </Target>
+  <Import Project="..\packages\ILRepack.MSBuild.Task.1.0.9\build\ILRepack.MSBuild.Task.targets" Condition="Exists('..\packages\ILRepack.MSBuild.Task.1.0.9\build\ILRepack.MSBuild.Task.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\ILRepack.MSBuild.Task.1.0.9\build\ILRepack.MSBuild.Task.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\ILRepack.MSBuild.Task.1.0.9\build\ILRepack.MSBuild.Task.targets'))" />
+  </Target>
 </Project>

--- a/Consul/Consul.csproj
+++ b/Consul/Consul.csproj
@@ -119,7 +119,7 @@
     <Message Text="DELETING: original files - @(FilesToDelete->'%(Filename)')" Importance="High" />
     <Delete Files="@(FilesToDelete)" />
     <Message Text="COPYING: @(FilesToCopy->'%(Filename)')" Importance="High" />
-    <Exec Command="xcopy /s $(OutputFolder)\*.* $(ProjectDir)$(OutputPath)" />
+    <Exec Command="xcopy /s /y $(OutputFolder)\*.* $(ProjectDir)$(OutputPath)" />
     <RemoveDir Directories="$(OutputFolder)" />
   </Target>
 </Project>

--- a/Consul/Consul.csproj
+++ b/Consul/Consul.csproj
@@ -39,8 +39,8 @@
     <AssemblyOriginatorKeyFile>..\assets\consuldotnet.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.8.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/Consul/Consul.csproj
+++ b/Consul/Consul.csproj
@@ -109,7 +109,7 @@
       <OutputFolder>$(OutputPath)\Standalone</OutputFolder>
       <OutputAssembly>$(OutputFolder)\$(OutputFileName)</OutputAssembly>
     </PropertyGroup>
-    <ILRepack Parallel="true" Internalize="true" InputAssemblies="@(InputAssemblies)" TargetKind="library" OutputFile="$(OutputAssembly)" />
+    <ILRepack Parallel="true" Internalize="true" XmlDocumentation="true" DebugInfo="true" InputAssemblies="@(InputAssemblies)" TargetKind="library" OutputFile="$(OutputAssembly)" />
     <Delete Files="@(FilesToDelete)" />
     <Copy SourceFiles="$(OutputAssembly)" DestinationFolder="$(OutputPath)" />
     <RemoveDir Directories="$(OutputFolder)" />

--- a/Consul/Consul.csproj
+++ b/Consul/Consul.csproj
@@ -112,7 +112,7 @@
       <MergerEXEPath>$(SolutionDir)packages\ILRepack.2.0.10\tools\ILRepack.exe</MergerEXEPath>
       <MergerEXE Condition="('$(OS)' == 'Windows_NT')">$(MergerEXEPath)</MergerEXE>
       <MergerEXE Condition="('$(OS)' != 'Windows_NT')">mono $(MergerEXEPath)</MergerEXE>
-      <MergerCommands>/keyfile:$(KeyFilePath) /parallel /internalize /xmldocs /out:$(FullOutputAssemblyPath) @(InputAssemblies->'%(FullPath)', ' ')</MergerCommands>
+      <MergerCommands>/keyfile:$(KeyFilePath) /parallel /internalize /out:$(FullOutputAssemblyPath) @(InputAssemblies->'%(FullPath)', ' ')</MergerCommands>
     </PropertyGroup>
     <Message Text="MERGING: @(InputAssemblies->'%(Filename)') into $(FullOutputAssemblyPath) with the command $(MergerEXE) $(MergerCommands)" Importance="High" />
     <Exec Command="$(MergerEXE) $(MergerCommands)" WorkingDirectory="$(OutputPath)" />

--- a/Consul/Consul.csproj
+++ b/Consul/Consul.csproj
@@ -98,27 +98,28 @@
   -->
   <Target Name="AfterBuild" Condition="'$(Configuration)' == 'Release'">
     <ItemGroup>
-      <InputAssemblies Include="$(OutputPath)\$(AssemblyName).dll" />
-      <InputAssemblies Include="$(OutputPath)\Newtonsoft.Json.dll" />
+      <InputAssemblies Include="$(ProjectDir)$(OutputPath)$(AssemblyName).dll" />
+      <InputAssemblies Include="$(ProjectDir)$(OutputPath)Newtonsoft.Json.dll" />
       <FilesToDelete Include="@(InputAssemblies)" />
-      <FilesToDelete Include="$(OutputPath)\Consul.pdb" />
-      <FilesToDelete Include="$(OutputPath)\Newtonsoft.Json.xml" />
+      <FilesToDelete Include="$(ProjectDir)$(OutputPath)Consul.pdb" />
+      <FilesToDelete Include="$(ProjectDir)$(OutputPath)Newtonsoft.Json.xml" />
     </ItemGroup>
     <PropertyGroup>
       <OutputFileName>$(AssemblyName).dll</OutputFileName>
-      <OutputFolder>$(OutputPath)\Standalone</OutputFolder>
-      <OutputAssembly>$(OutputFolder)\$(OutputFileName)</OutputAssembly>
+      <OutputFolder>$(ProjectDir)$(OutputPath)Standalone</OutputFolder>
+      <FullOutputAssemblyPath>$(OutputFolder)\$(OutputFileName)</FullOutputAssemblyPath>
+      <KeyFilePath>$(ProjectDir)$(AssemblyOriginatorKeyFile)</KeyFilePath>
+      <MergerEXEPath>$(SolutionDir)packages\ILRepack.2.0.10\tools\ILRepack.exe</MergerEXEPath>
+      <MergerEXE Condition="('$(OS)' == 'Windows_NT')">$(MergerEXEPath)</MergerEXE>
+      <MergerEXE Condition="('$(OS)' != 'Windows_NT')">mono $(MergerEXEPath)</MergerEXE>
+      <MergerCommands>/keyfile:$(KeyFilePath) /parallel /internalize /xmldocs /out:$(FullOutputAssemblyPath) @(InputAssemblies->'%(FullPath)', ' ')</MergerCommands>
     </PropertyGroup>
-    <ILRepack KeyFile="$(AssemblyOriginatorKeyFile)" Parallel="true" Internalize="true" XmlDocumentation="true" DebugInfo="true" InputAssemblies="@(InputAssemblies)" TargetKind="Dll" OutputFile="$(OutputAssembly)" />
+    <Message Text="MERGING: @(InputAssemblies->'%(Filename)') into $(FullOutputAssemblyPath) with the command $(MergerEXE) $(MergerCommands)" Importance="High" />
+    <Exec Command="$(MergerEXE) $(MergerCommands)" WorkingDirectory="$(OutputPath)" />
+    <Message Text="DELETING: original files - @(FilesToDelete->'%(Filename)')" Importance="High" />
     <Delete Files="@(FilesToDelete)" />
-    <Copy SourceFiles="$(OutputAssembly)" DestinationFolder="$(OutputPath)" />
+    <Message Text="COPYING: @(FilesToCopy->'%(Filename)')" Importance="High" />
+    <Exec Command="xcopy /s $(OutputFolder)\*.* $(ProjectDir)$(OutputPath)" />
     <RemoveDir Directories="$(OutputFolder)" />
-  </Target>
-  <Import Project="..\packages\ILRepack.MSBuild.Task.1.0.9\build\ILRepack.MSBuild.Task.targets" Condition="Exists('..\packages\ILRepack.MSBuild.Task.1.0.9\build\ILRepack.MSBuild.Task.targets')" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('..\packages\ILRepack.MSBuild.Task.1.0.9\build\ILRepack.MSBuild.Task.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\ILRepack.MSBuild.Task.1.0.9\build\ILRepack.MSBuild.Task.targets'))" />
   </Target>
 </Project>

--- a/Consul/Properties/AssemblyInfo.cs
+++ b/Consul/Properties/AssemblyInfo.cs
@@ -34,7 +34,7 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("0.6.1.0")]
 [assembly: AssemblyFileVersion("0.6.1.0")]
-[assembly: InternalsVisibleTo("Consul.Test,PublicKey=" +
+[assembly: InternalsVisibleTo("Consul.Test, PublicKey=" +
     "002400000480000094000000060200000024000052534131000400000100010045f6337bf03a95" +
     "218f1e0b4e70bb91f8ee49fcb58593d78c1008ee646cfcf785ea60bd0b1dde6f5f92ead738e2bd" +
     "7f31ee9c209bbedbe1fd0cc5ee2ea60e73099044d2fa7ba1e8f0971fae411f42c6e8fab787d39a" +

--- a/Consul/packages.config
+++ b/Consul/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="ILRepack" version="2.0.10" targetFramework="net45" developmentDependency="true" />
-  <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" userInstalled="true" developmentDependency="true" />
+  <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net45" userInstalled="true" developmentDependency="true" />
 </packages>

--- a/Consul/packages.config
+++ b/Consul/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="ILRepack.MSBuild.Task" version="1.0.9" targetFramework="net45" developmentDependency="true" />
+  <package id="ILRepack" version="2.0.10" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net45" userInstalled="true" developmentDependency="true" />
 </packages>

--- a/Consul/packages.config
+++ b/Consul/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="ILRepack" version="2.0.10" targetFramework="net45" developmentDependency="true" />
+  <package id="ILRepack.MSBuild.Task" version="1.0.9" targetFramework="net45" developmentDependency="true" />
   <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net45" userInstalled="true" developmentDependency="true" />
 </packages>

--- a/Consul/packages.config
+++ b/Consul/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="ILRepack.MSBuild.Task" version="1.0.9" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" userInstalled="true" />
+  <package id="ILRepack" version="2.0.10" targetFramework="net45" developmentDependency="true" />
+  <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" userInstalled="true" developmentDependency="true" />
 </packages>

--- a/Consul/packages.config
+++ b/Consul/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="ILRepack.MSBuild.Task" version="1.0.9" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" userInstalled="true" />
 </packages>

--- a/Consul/packages.config
+++ b/Consul/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="ILRepack" version="2.0.10" targetFramework="net45" />
+  <package id="ILRepack" version="2.0.10" targetFramework="net45" developmentDependency="true" />
   <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net45" userInstalled="true" developmentDependency="true" />
 </packages>


### PR DESCRIPTION
In order to reduce the clashing of JSON.net dependencies, this PR adds build steps that, on a release build, will take Newtonsoft.json.dll and package it into the Consul.dll. When others import the Consul.dll file, they can use whatever version of JSON.net they want and it will not clash with the version used by Consul.dll. This relates to issue #28.