### PR TITLE
Adding PreparedQuery to IConsulClient

### DIFF
--- a/Consul/Interfaces/IConsulClient.cs
+++ b/Consul/Interfaces/IConsulClient.cs
@@ -32,5 +32,6 @@ namespace Consul
         ISessionEndpoint Session { get; }
         IStatusEndpoint Status { get; }
         IOperatorEndpoint Operator { get; }
+        IPreparedQueryEndpoint PreparedQuery { get; }
     }
 }


### PR DESCRIPTION
The Prepared Query interface was missing from the Consul client interface.  