### PR TITLE
Check addrParts for length before parsing port number

### DIFF
--- a/Consul/Client.cs
+++ b/Consul/Client.cs
@@ -202,7 +202,7 @@ namespace Consul
                 {
                     consulAddress.Host = addrParts[0];
                 }
-                if (!string.IsNullOrEmpty(addrParts[1]))
+                if (addrParts.Length > 1 && !string.IsNullOrEmpty(addrParts[1]))
                 {
                     try
                     {


### PR DESCRIPTION
Check addrParts for length before parsing port number in CONSUL_HTTP_ADDR environment variable. Fixes https://github.com/PlayFab/consuldotnet/issues/89 issue