### PR TITLE
Cancel Lock's token if consul is not available

### DIFF
--- a/Consul/Lock.cs
+++ b/Consul/Lock.cs
@@ -502,6 +502,7 @@ namespace Consul
                 finally
                 {
                     IsHeld = false;
+                    DisposeCancellationTokenSource();
                 }
             }, CancellationToken.None, TaskCreationOptions.LongRunning, TaskScheduler.Default).Unwrap();
         }


### PR DESCRIPTION
Hi guys!

I found very strange behaviour: lock's cancellationtoken is not cancelled when consul is down, but IsHeld property is set to false.

You can reproduce this issue in several steps:

1. Run this code.

```
public static class Program
    {
        public static void Main()
        {
            var consulClient = new ConsulClient();
            var consulLock = consulClient.CreateLock("Lock");
            var consulLockCancellation = consulLock.Acquire(CancellationToken.None).GetAwaiter().GetResult();
            while (true)
            {
                Console.WriteLine($"{consulLock.IsHeld} {consulLockCancellation.IsCancellationRequested}");

                Task.Delay(1000).GetAwaiter().GetResult();
            }
        }
}
```
2. Expected output is "True False" every one second and it matches with actual.
3. Turn off consul.
4. Expected output is "False True" every one second and it doesn't match with actual "False False".

Here is probably a fix for this issue.

