### PR TITLE
fix ConsulRequest json deserialization when propertyName is RegEx

### DIFF
--- a/Consul/Utilities/JsonConverters.cs
+++ b/Consul/Utilities/JsonConverters.cs
@@ -91,31 +91,33 @@ namespace Consul
                 {
                     string jsonPropName = reader.Value.ToString();
                     var propName = objProps.Value.FirstOrDefault(p => p.Equals(jsonPropName, StringComparison.OrdinalIgnoreCase));
+                    if (propName != null)
+                    {
+                        PropertyInfo pi = result.GetType().GetRuntimeProperty(propName);
 
-                    PropertyInfo pi = result.GetType().GetRuntimeProperty(propName);
-
-                    if (jsonPropName.Equals("Flags", StringComparison.OrdinalIgnoreCase))
-                    {
-                        if (!string.IsNullOrEmpty(reader.ReadAsString()))
+                        if (jsonPropName.Equals("Flags", StringComparison.OrdinalIgnoreCase))
                         {
-                            var val = Convert.ToUInt64(reader.Value);
-                            pi.SetValue(result, val, null);
+                            if (!string.IsNullOrEmpty(reader.ReadAsString()))
+                            {
+                                var val = Convert.ToUInt64(reader.Value);
+                                pi.SetValue(result, val, null);
+                            }
                         }
-                    }
-                    else if (jsonPropName.Equals("Value", StringComparison.OrdinalIgnoreCase))
-                    {
-                        if (!string.IsNullOrEmpty(reader.ReadAsString()))
+                        else if (jsonPropName.Equals("Value", StringComparison.OrdinalIgnoreCase))
                         {
-                            var val = Convert.FromBase64String(reader.Value.ToString());
-                            pi.SetValue(result, val, null);
+                            if (!string.IsNullOrEmpty(reader.ReadAsString()))
+                            {
+                                var val = Convert.FromBase64String(reader.Value.ToString());
+                                pi.SetValue(result, val, null);
+                            }
                         }
-                    }
-                    else
-                    {
-                        if (reader.Read())
+                        else
                         {
-                            var convertedValue = Convert.ChangeType(reader.Value, pi.PropertyType);
-                            pi.SetValue(result, convertedValue, null);
+                            if (reader.Read())
+                            {
+                                var convertedValue = Convert.ChangeType(reader.Value, pi.PropertyType);
+                                pi.SetValue(result, convertedValue, null);
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
I got the following exception in our dotnet core project when connecting to Consul remote servers in our company:
ArgumentNullException: Value cannot be null.
 Parameter name: name
System.Type.GetProperty(string name, BindingFlags bindingAttr)
System.Reflection.RuntimeReflectionExtensions.GetRuntimeProperty(Type type, string name)
Consul.KVPairConverter.ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
Newtonsoft.Json.Serialization.JsonSerializerInternalReader.DeserializeConvertable(JsonConverter converter, JsonReader reader, Type objectType, object existingValue)
Newtonsoft.Json.Serialization.JsonSerializerInternalReader.PopulateList(IList list, JsonReader reader, JsonArrayContract contract, JsonProperty containerProperty, string id)
Newtonsoft.Json.Serialization.JsonSerializerInternalReader.CreateList(JsonReader reader, Type objectType, JsonContract contract, JsonProperty member, object existingValue, string id)
Newtonsoft.Json.Serialization.JsonSerializerInternalReader.Deserialize(JsonReader reader, Type objectType, bool checkAdditionalContent)
Newtonsoft.Json.JsonSerializer.DeserializeInternal(JsonReader reader, Type objectType)
Newtonsoft.Json.JsonSerializer.Deserialize<T>(JsonReader reader)
Consul.ConsulRequest.Deserialize<TOut>(Stream stream)
Consul.GetRequest+<Execute>d__5.MoveNext()
System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
Consul.KV+<Get>d__13.MoveNext()
System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
System.Runtime.CompilerServices.TaskAwaiter.GetResult()
WebApplication2.Controllers.ValuesController+<Get>d__0.MoveNext() 
