### PR TITLE
Add ServiceMeta dictionary to CatalogService

### DIFF
--- a/Consul/Catalog.cs
+++ b/Consul/Catalog.cs
@@ -44,6 +44,7 @@ namespace Consul
         public string[] ServiceTags { get; set; }
         public int ServicePort { get; set; }
         public bool ServiceEnableTagOverride { get; set; }
+        public IDictionary<string,string> ServiceMeta { get; set; }
     }
 
     public class CatalogNode


### PR DESCRIPTION
Makes service meta data available to the client. Fixes #113 