### PR TITLE
Fix NullReferenceException when calling Lock.Acquire with CancellationToken

### DIFF
--- a/Consul.Test/LockTest.cs
+++ b/Consul.Test/LockTest.cs
@@ -38,7 +38,7 @@ namespace Consul.Test
         {
             m_lock.Dispose();
         }
-    
+
         [Fact]
         public async Task Lock_AcquireRelease()
         {
@@ -666,6 +666,27 @@ namespace Consul.Test
                 catch (LockNotHeldException ex)
                 {
                     Assert.IsType<LockNotHeldException>(ex);
+                }
+            }
+        }
+
+        [Fact]
+        public async Task Lock_AcquireTimeout()
+        {
+            using (var client = new ConsulClient())
+            {
+                const string keyName = "test/lock/acquiretimeout";
+                var distributedLock = await client.AcquireLock(keyName);
+                try
+                {
+                    using (var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5)))
+                    {
+                        await Assert.ThrowsAsync<LockNotHeldException>(() => client.AcquireLock(keyName, cts.Token));
+                    }
+                }
+                finally
+                {
+                    await distributedLock.Release();
                 }
             }
         }

--- a/Consul/Lock.cs
+++ b/Consul/Lock.cs
@@ -331,11 +331,21 @@ namespace Consul
                 if (ct.IsCancellationRequested || (!IsHeld && !string.IsNullOrEmpty(Opts.Session)))
                 {
                     DisposeCancellationTokenSource();
-                    if (_sessionRenewTask != null)
+                    if (_monitorTask != null)
                     {
                         try
                         {
                             await _monitorTask.ConfigureAwait(false);
+                        }
+                        catch (AggregateException)
+                        {
+                            // Ignore AggregateExceptions from the tasks during Release, since if the Monitor task died, the developer will be Super Confused if they see the exception during Release.
+                        }
+                    }
+                    if (_sessionRenewTask != null)
+                    {
+                        try
+                        {
                             await _sessionRenewTask.ConfigureAwait(false);
                         }
                         catch (AggregateException)


### PR DESCRIPTION
This is the same fix that is in the 0.9 port branch, but appears to have been forgotten about for over a year.