### PR TITLE
Add ?cached query parameter

### DIFF
--- a/Consul/Agent.cs
+++ b/Consul/Agent.cs
@@ -141,6 +141,7 @@ namespace Consul
         public int Port { get; set; }
         public string Address { get; set; }
         public bool EnableTagOverride { get; set; }
+        public IDictionary<string, string> Meta { get; set; }
     }
 
     /// <summary>
@@ -194,6 +195,9 @@ namespace Consul
 
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public AgentServiceCheck[] Checks { get; set; }
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public IDictionary<string, string> Meta { get; set; }
     }
 
     /// <summary>

--- a/Consul/Client.cs
+++ b/Consul/Client.cs
@@ -318,7 +318,8 @@ namespace Consul
             Consistency = ConsistencyMode.Default,
             Datacenter = string.Empty,
             Token = string.Empty,
-            WaitIndex = 0
+            WaitIndex = 0,
+            Cached = false
         };
 
         /// <summary>
@@ -353,6 +354,13 @@ namespace Consul
         /// for the sort.
         /// </summary>
         public string Near { get; set; }
+
+        /// <summary>
+        /// This query flag will tell the consul agent to return a cached resource, if the endpoint supports caching.
+        /// Some read endpoints support agent caching. They are clearly marked in the documentation. Agent caching can take two forms, simple or background refresh depending on the endpoint's semantics.
+        /// https://www.consul.io/api/index.html
+        /// </summary>
+        public bool Cached { get; set; }
     }
 
     /// <summary>
@@ -1044,6 +1052,10 @@ namespace Consul
             if (!string.IsNullOrEmpty(Options.Near))
             {
                 Params["near"] = Options.Near;
+            }
+            if (Options.Cached)
+            {
+                Params["cached"] = string.Empty;
             }
         }
 


### PR DESCRIPTION
Add ?cached query parameter to QueryOptions allowing calls to return the cached resource from the agent, according to the API specification: https://www.consul.io/api/index.html